### PR TITLE
LV2: Pass through program change MIDI events to plugin

### DIFF
--- a/source/backend/plugin/Lv2Plugin.cpp
+++ b/source/backend/plugin/Lv2Plugin.cpp
@@ -3024,6 +3024,23 @@ public:
                                 }
                             }
                         }
+                        else
+                        {
+                            uint8_t midiData[2];
+                            midiData[0] = uint8_t(MIDI_STATUS_PROGRAM_CHANGE | (event.channel & MIDI_CHANNEL_BIT));
+                            midiData[1] = ctrlEvent.param;
+
+                            const uint32_t mtime(isSampleAccurate ? startTime : event.time);
+
+                            if (fEventsIn.ctrl->type & CARLA_EVENT_DATA_ATOM)
+                                lv2_atom_buffer_write(&evInAtomIters[fEventsIn.ctrlIndex], mtime, 0, CARLA_URI_MAP_ID_MIDI_EVENT, 2, midiData);
+
+                            else if (fEventsIn.ctrl->type & CARLA_EVENT_DATA_EVENT)
+                                lv2_event_write(&evInEventIters[fEventsIn.ctrlIndex], mtime, 0, CARLA_URI_MAP_ID_MIDI_EVENT, 2, midiData);
+
+                            else if (fEventsIn.ctrl->type & CARLA_EVENT_DATA_MIDI_LL)
+                                lv2midi_put_event(&evInMidiStates[fEventsIn.ctrlIndex], mtime, 2, midiData);
+                        }
                         break;
 
                     case kEngineControlEventTypeAllSoundOff:


### PR DESCRIPTION
Send through program change MIDI events to the plugin if they are not mapped. This is useful when a LV2 plugin implements program changes (per channel) itself.

If there should be a "Send Program Changes" option to make it possible to control whether to send these events to the plugin, akin to the other "Send XXX" options. I have an implementation of this here: https://github.com/laanwj/Carla/tree/2014_09_send_midi 
