### PR TITLE
Correct buffersize in LV2 plugin UI port MIDI events

### DIFF
--- a/source/backend/plugin/Lv2Plugin.cpp
+++ b/source/backend/plugin/Lv2Plugin.cpp
@@ -3835,7 +3835,7 @@ public:
                 midiEv.data[1] = note;
                 midiEv.data[2] = velo;
 
-                fUI.descriptor->port_event(fUI.handle, fEventsIn.ctrl->rindex, 3, CARLA_URI_MAP_ID_ATOM_TRANSFER_ATOM, &midiEv);
+                fUI.descriptor->port_event(fUI.handle, fEventsIn.ctrl->rindex, sizeof(LV2_Event) + 3, CARLA_URI_MAP_ID_ATOM_TRANSFER_ATOM, &midiEv);
             }
         }
     }
@@ -3868,7 +3868,7 @@ public:
                 midiEv.data[1] = note;
                 midiEv.data[2] = 0;
 
-                fUI.descriptor->port_event(fUI.handle, fEventsIn.ctrl->rindex, 3, CARLA_URI_MAP_ID_ATOM_TRANSFER_ATOM, &midiEv);
+                fUI.descriptor->port_event(fUI.handle, fEventsIn.ctrl->rindex, sizeof(LV2_Event) + 3, CARLA_URI_MAP_ID_ATOM_TRANSFER_ATOM, &midiEv);
             }
         }
     }


### PR DESCRIPTION
Not sure if the number should be rounded up to 64-bit. In any case, passing 3 here is not quite right as there is an event header before it.
