### PR TITLE
Highlight port and connections on hover.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 # Temp files
 *~
 *.bak
+*.swp
+*.swo
 
 # Binary files
 *.7z

--- a/source/patchcanvas.py
+++ b/source/patchcanvas.py
@@ -1764,6 +1764,7 @@ class CanvasPort(QGraphicsItem):
         self.m_cursor_moving = False
 
         self.setFlags(QGraphicsItem.ItemIsSelectable)
+        self.setAcceptHoverEvents(True)
 
     def getGroupId(self):
         return self.m_group_id
@@ -1813,6 +1814,17 @@ class CanvasPort(QGraphicsItem):
 
     def type(self):
         return CanvasPortType
+
+    def hoverEnterEvent(self, event):
+        self.setSelected(True)
+        QGraphicsItem.hoverEnterEvent(self, event)
+
+    def hoverLeaveEvent(self, event):
+        self.setSelected(False)
+        QGraphicsItem.hoverLeaveEvent(self, event)
+
+    def hoverMoveEvent(self, event):
+        QGraphicsItem.hoverMoveEvent(self, event)
 
     def mousePressEvent(self, event):
         self.m_hover_item = None


### PR DESCRIPTION
Testing the waters. IMHO this makes the patchbay feel more responsive, but let me know if it clashes with existing behavior.

I'm also thinking of implementing the following behavior: if you're dragging a wire from e.g. an audio output, then all ports that are not audio inputs are darkened so you can easily see the possible destinations for dropping that wire. Would you be opposed to me refactoring the themes first, though?