### PR TITLE
Add a hide file browser menu option (fixes #199)

### DIFF
--- a/resources/ui/carla_host.ui
+++ b/resources/ui/carla_host.ui
@@ -226,6 +226,7 @@
     <addaction name="act_settings_show_toolbar"/>
     <addaction name="act_settings_show_meters"/>
     <addaction name="act_settings_show_keyboard"/>
+    <addaction name="act_settings_show_side_panel"/>
     <addaction name="separator"/>
     <addaction name="act_settings_configure"/>
    </widget>
@@ -804,6 +805,14 @@
    </property>
    <property name="text">
     <string>Show Time Panel</string>
+   </property>
+  </action>
+  <action name="act_settings_show_side_panel">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show &amp;Side Panel</string>
    </property>
   </action>
   <action name="act_file_connect">

--- a/source/carla_host.py
+++ b/source/carla_host.py
@@ -378,6 +378,7 @@ class HostWindow(QMainWindow):
         self.ui.act_settings_show_toolbar.toggled.connect(self.slot_showToolbar)
         self.ui.act_settings_show_meters.toggled.connect(self.slot_showCanvasMeters)
         self.ui.act_settings_show_keyboard.toggled.connect(self.slot_showCanvasKeyboard)
+        self.ui.act_settings_show_side_panel.toggled.connect(self.slot_showSidePanel)
         self.ui.act_settings_configure.triggered.connect(self.slot_configureCarla)
 
         self.ui.act_help_about.triggered.connect(self.slot_aboutCarla)
@@ -1219,6 +1220,8 @@ class HostWindow(QMainWindow):
 
         settings.setValue("ShowToolbar", self.ui.toolBar.isEnabled())
 
+        settings.setValue("ShowSidePanel", self.ui.dockWidget.isEnabled())
+
         diskFolders = []
 
         for i in range(self.ui.cb_disk.count()):
@@ -1257,6 +1260,11 @@ class HostWindow(QMainWindow):
                 #self.ui.splitter.restoreState(settings.value("SplitterState", b""))
             #else:
                 #self.ui.splitter.setSizes([210, 99999])
+
+            showSidePanel = settings.value("ShowSidePanel", True, type=bool)
+            self.ui.act_settings_show_side_panel.setChecked(showSidePanel)
+            self.ui.dockWidget.setEnabled(showSidePanel)
+            self.ui.dockWidget.setVisible(showSidePanel)
 
             diskFolders = toList(settings.value("DiskFolders", [HOME]))
 
@@ -1320,6 +1328,11 @@ class HostWindow(QMainWindow):
     @pyqtSlot(bool)
     def slot_showTimePanel(self, yesNo):
         self.ui.panelTime.setVisible(yesNo)
+
+    @pyqtSlot(bool)
+    def slot_showSidePanel(self, yesNo):
+        self.ui.dockWidget.setEnabled(yesNo)
+        self.ui.dockWidget.setVisible(yesNo)
 
     @pyqtSlot(bool)
     def slot_showToolbar(self, yesNo):


### PR DESCRIPTION
This defaults to the panel still showing up on newly updated versions. 