### PR TITLE
Fix build on GCC 5.3.0, where isnan ends up being undeclared otherwise.

### DIFF
--- a/source/native-plugins/zynaddsubfx-src.cpp
+++ b/source/native-plugins/zynaddsubfx-src.cpp
@@ -25,6 +25,8 @@
 using std::isnan;
 #else
 # include <err.h>
+#include <cmath>
+using std::isnan;
 #endif
 
 #define PLUGINVERSION


### PR DESCRIPTION
@falkTX without this I'm getting
```
Compiling zynaddsubfx-src.cpp
In file included from zynaddsubfx/DSP/FFTwrapper.cpp:27:0,
                 from zynaddsubfx-src.cpp:74:
zynaddsubfx/DSP/FFTwrapper.h: In instantiation of ‘std::complex<_Tp> FFTpolar(const _Tp&, const _Tp&) [with _Tp = float]’:
zynaddsubfx/Params/PADnoteParameters.cpp:872:68:   required from here
zynaddsubfx/DSP/FFTwrapper.h:61:18: error: ‘isnan’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
         if (isnan(__x))
                  ^
In file included from /usr/include/c++/5.3.0/random:38:0,
                 from /usr/include/c++/5.3.0/bits/stl_algo.h:66,
                 from /usr/include/c++/5.3.0/algorithm:62,
                 from zynaddsubfx/rtosc/cpp/midimapper.cpp:4,
                 from zynaddsubfx-src.cpp:58:
/usr/include/c++/5.3.0/cmath:641:5: note: ‘template<class _Tp> constexpr typename __gnu_cxx::__enable_if<std::__is_integer<_Tp>::__value, bool>::__type std::isnan(_Tp)’ declared here, later in the translation unit
     isnan(_Tp __x)
     ^
```
on the latest master.