### PR TITLE
Fix #380: Limit stack allocation during base64 encoding

### DIFF
--- a/source/utils/CarlaString.hpp
+++ b/source/utils/CarlaString.hpp
@@ -20,6 +20,7 @@
 
 #include "CarlaJuceUtils.hpp"
 #include "CarlaMathUtils.hpp"
+#include <algorithm>
 
 // -----------------------------------------------------------------------
 // CarlaString class
@@ -585,7 +586,7 @@ public:
             "abcdefghijklmnopqrstuvwxyz"
             "0123456789+/";
 
-        const std::size_t kTmpBufSize = carla_nextPowerOf2(static_cast<uint32_t>(dataSize/3));
+        const std::size_t kTmpBufSize = std::min(carla_nextPowerOf2(static_cast<uint32_t>(dataSize/3)), 65536U);
 
         const uchar* bytesToEncode((const uchar*)data);
 


### PR DESCRIPTION
Some VST plugins want to save a large binary chunk of state. For example,
Drumlab inside Kontakt 5 saves 1.5MB of data. We shouldn't allocate that
much on the stack.