### PR TITLE
changes to implement #244 - send bank and program change for vst2

### DIFF
--- a/source/backend/plugin/CarlaPluginJuce.cpp
+++ b/source/backend/plugin/CarlaPluginJuce.cpp
@@ -161,6 +161,7 @@ public:
             options |= PLUGIN_OPTION_SEND_NOTE_AFTERTOUCH;
             options |= PLUGIN_OPTION_SEND_PITCHBEND;
             options |= PLUGIN_OPTION_SEND_ALL_SOUND_OFF;
+            options |= PLUGIN_OPTION_SEND_PROGRAM_CHANGES;
         }
 
         return options;
@@ -854,7 +855,19 @@ public:
                     } // case kEngineControlEventTypeParameter
 
                     case kEngineControlEventTypeMidiBank:
-                        break;
+                        if ((pData->options & PLUGIN_OPTION_SEND_PROGRAM_CHANGES) != 0)
+                        {
+                            uint8_t midiData[3];
+                            midiData[0] = uint8_t(MIDI_STATUS_CONTROL_CHANGE | (event.channel & MIDI_CHANNEL_BIT));
+                            midiData[1] = MIDI_CONTROL_BANK_SELECT__LSB;
+                            midiData[2] = uint8_t(ctrlEvent.value*127.0f);
+                            fMidiBuffer.addEvent(midiData, 3, static_cast<int>(event.time));
+
+                            midiData[1] = MIDI_CONTROL_BANK_SELECT; 
+                            midiData[2] = 0;
+                            fMidiBuffer.addEvent(midiData, 2, static_cast<int>(event.time));
+                        }
+                        break;                    
 
                     case kEngineControlEventTypeMidiProgram:
                         if (event.channel == pData->ctrlChannel && (pData->options & PLUGIN_OPTION_MAP_PROGRAM_CHANGES) != 0)
@@ -863,9 +876,15 @@ public:
                             {
                                 setProgram(ctrlEvent.param, false, false, false);
                                 pData->postponeRtEvent(kPluginPostRtEventProgramChange, ctrlEvent.param, 0, 0.0f);
-                                break;
                             }
                         }
+                        else if ((pData->options & PLUGIN_OPTION_SEND_PROGRAM_CHANGES) != 0)
+                        {
+                            uint8_t midiData[3];
+                            midiData[0] = uint8_t(MIDI_STATUS_PROGRAM_CHANGE | (event.channel & MIDI_CHANNEL_BIT));
+                            midiData[1] = uint8_t(ctrlEvent.value*127.0f);
+                            fMidiBuffer.addEvent(midiData, 2, static_cast<int>(event.time));
+                        }                        
                         break;
 
                     case kEngineControlEventTypeAllSoundOff:
@@ -1223,9 +1242,6 @@ public:
         pData->options |= PLUGIN_OPTION_FIXED_BUFFERS;
         pData->options |= PLUGIN_OPTION_USE_CHUNKS;
 
-        if (fInstance->getNumPrograms() > 1)
-            pData->options |= PLUGIN_OPTION_MAP_PROGRAM_CHANGES;
-
         if (fInstance->acceptsMidi())
         {
             pData->options |= PLUGIN_OPTION_SEND_CHANNEL_PRESSURE;
@@ -1235,7 +1251,12 @@ public:
 
             if (options & PLUGIN_OPTION_SEND_CONTROL_CHANGES)
                 pData->options |= PLUGIN_OPTION_SEND_CONTROL_CHANGES;
+            if (options & PLUGIN_OPTION_SEND_PROGRAM_CHANGES)
+                pData->options |= PLUGIN_OPTION_SEND_PROGRAM_CHANGES;                            
         }
+
+        if ((fInstance->getNumPrograms() > 1) & ((pData->options & PLUGIN_OPTION_SEND_PROGRAM_CHANGES) == 0))
+            pData->options |= PLUGIN_OPTION_MAP_PROGRAM_CHANGES;        
 
         return true;
     }

--- a/source/backend/plugin/CarlaPluginVST2.cpp
+++ b/source/backend/plugin/CarlaPluginVST2.cpp
@@ -1324,6 +1324,7 @@ public:
                             vstMidiEvent_MSB.midiData[1] = MIDI_CONTROL_BANK_SELECT;
                             vstMidiEvent_MSB.midiData[2] = 0; 
                         }
+                        break;
 
                     case kEngineControlEventTypeMidiProgram:
                         if (event.channel == pData->ctrlChannel && (pData->options & PLUGIN_OPTION_MAP_PROGRAM_CHANGES) != 0)


### PR DESCRIPTION
I've had a go at implementing changes to make bank and program change work for vst2 along the lines suggested in #244 and following similar code mentioned for LV2

As with others in #244, I have a win32 vst (AAS' Lounge Lizard) that provides several different banks (as well as programs in each bank) that can be changed via MIDI - currently not possible in Carla.

I can compile my changes, but I'm running 16.04 and can't build carla with win32 vst support as I can't install mingw32 (it's not available for xenial?), so my changes are untested (sorry).  BTW I'm following [this guide for compiling from source](https://www.linuxmusicians.com/viewtopic.php?t=12812) - hopefully that's appropriate!

I realise this is probably not a priority but I'm keen to help in any way I can to get this merged (or if you'd prefer not to merge, any help on compiling for xenial, if possible, would be appreciated!)

My needs are quite simple (I only need this plugin - for now!) so I'm probable using the wrong tools for the job - but I also can't get wineasio to work, whereas Carla works perfectly!  

Thanks for your work on this great set of tools :)