### PR TITLE
Fix a couple of parallel build problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,13 +112,13 @@ $(MODULEDIR)/jackbridge.%.a: .FORCE
 $(MODULEDIR)/native-plugins.a: .FORCE
 	@$(MAKE) -C source/native-plugins
 
-$(MODULEDIR)/theme.a: .FORCE
+$(MODULEDIR)/theme.a: theme .FORCE
 	@$(MAKE) -C source/theme
 
-$(MODULEDIR)/theme.qt4.a: .FORCE
+$(MODULEDIR)/theme.qt4.a: theme .FORCE
 	@$(MAKE) -C source/theme qt4
 
-$(MODULEDIR)/theme.qt5.a: .FORCE
+$(MODULEDIR)/theme.qt5.a: theme .FORCE
 	@$(MAKE) -C source/theme qt5
 
 $(MODULEDIR)/%.posix32.a: .FORCE

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ bridges-ui: libs
 discovery: libs
 	@$(MAKE) -C source/discovery
 
-interposer:
+interposer: libs
 	@$(MAKE) -C source/interposer
 
 plugin: backend bridges-plugin bridges-ui discovery


### PR DESCRIPTION
I build carla with make -j8; these patches fix a couple of dependency problems that cause occasional parallel make failures.