### PR TITLE
add semitones parameter to midi-transpose plugin

### DIFF
--- a/source/native-plugins/_data.all.cpp
+++ b/source/native-plugins/_data.all.cpp
@@ -155,7 +155,7 @@ static const NativePluginDescriptor sNativePluginDescriptors[] = {
     /* audioOuts */ 0,
     /* midiIns   */ 1,
     /* midiOuts  */ 1,
-    /* paramIns  */ 1,
+    /* paramIns  */ 2,
     /* paramOuts */ 0,
     /* name      */ "MIDI Transpose",
     /* label     */ "miditranspose",

--- a/source/native-plugins/_data.base.cpp
+++ b/source/native-plugins/_data.base.cpp
@@ -139,7 +139,7 @@ static const NativePluginDescriptor sNativePluginDescriptors[] = {
     /* audioOuts */ 0,
     /* midiIns   */ 1,
     /* midiOuts  */ 1,
-    /* paramIns  */ 1,
+    /* paramIns  */ 2,
     /* paramOuts */ 0,
     /* name      */ "MIDI Transpose",
     /* label     */ "miditranspose",

--- a/source/native-plugins/midi-transpose.c
+++ b/source/native-plugins/midi-transpose.c
@@ -26,7 +26,6 @@ typedef struct {
     const NativeHostDescriptor* host;
     int octaves;
     int semitones;
-    bool invert;
 } MidiTransposeHandle;
 
 // -----------------------------------------------------------------------
@@ -101,11 +100,13 @@ static float miditranspose_get_parameter_value(NativePluginHandle handle, uint32
     switch (index)
     {
         case 0:
-        return (float)handlePtr->octaves;
+            return (float)handlePtr->octaves;
+            break;
         case 1:
-        return (float)handlePtr->semitones;
+            return (float)handlePtr->semitones;
+            break;
         default:
-        return 0.0f;
+            return 0.0f;
     }
 }
 
@@ -114,11 +115,13 @@ static void miditranspose_set_parameter_value(NativePluginHandle handle, uint32_
   switch (index)
   {
       case 0:
-      handlePtr->octaves = (int)value;
+          handlePtr->octaves = (int)value;
+          break;
       case 1:
-      handlePtr->semitones = (int)value;
+          handlePtr->semitones = (int)value;
+          break;
       default:
-      return;
+          return;
   }
 
 }

--- a/source/native-plugins/midi-transpose.c
+++ b/source/native-plugins/midi-transpose.c
@@ -101,10 +101,8 @@ static float miditranspose_get_parameter_value(NativePluginHandle handle, uint32
     {
         case 0:
             return (float)handlePtr->octaves;
-            break;
         case 1:
             return (float)handlePtr->semitones;
-            break;
         default:
             return 0.0f;
     }
@@ -116,10 +114,8 @@ static void miditranspose_set_parameter_value(NativePluginHandle handle, uint32_
     {
         case 0:
             handlePtr->octaves = (int)value;
-            break;
         case 1:
             handlePtr->semitones = (int)value;
-            break;
         default:
             return;
     }

--- a/source/native-plugins/midi-transpose.c
+++ b/source/native-plugins/midi-transpose.c
@@ -60,7 +60,7 @@ static uint32_t miditranspose_get_parameter_count(NativePluginHandle handle)
 
 static const NativeParameter* miditranspose_get_parameter_info(NativePluginHandle handle, uint32_t index)
 {
-    if (index >= miditranspose_get_parameter_count(handle))
+    if (index >= 2)
         return NULL;
 
     static NativeParameter param[] =

--- a/source/native-plugins/midi-transpose.c
+++ b/source/native-plugins/midi-transpose.c
@@ -25,6 +25,8 @@
 typedef struct {
     const NativeHostDescriptor* host;
     int octaves;
+    int semitones;
+    bool invert;
 } MidiTransposeHandle;
 
 // -----------------------------------------------------------------------
@@ -38,6 +40,7 @@ static NativePluginHandle miditranspose_instantiate(const NativeHostDescriptor* 
 
     handle->host    = host;
     handle->octaves = 0;
+    handle->semitones = 0;
     return handle;
 }
 
@@ -50,7 +53,7 @@ static void miditranspose_cleanup(NativePluginHandle handle)
 
 static uint32_t miditranspose_get_parameter_count(NativePluginHandle handle)
 {
-    return 1;
+    return 2;
 
     // unused
     (void)handle;
@@ -58,50 +61,74 @@ static uint32_t miditranspose_get_parameter_count(NativePluginHandle handle)
 
 static const NativeParameter* miditranspose_get_parameter_info(NativePluginHandle handle, uint32_t index)
 {
-    if (index != 0)
+    if (index >= miditranspose_get_parameter_count(handle))
         return NULL;
 
-    static NativeParameter param;
-
-    param.name  = "Octaves";
-    param.unit  = NULL;
-    param.hints = NATIVE_PARAMETER_IS_ENABLED|NATIVE_PARAMETER_IS_AUTOMABLE|NATIVE_PARAMETER_IS_INTEGER;
-    param.ranges.def = 0.0f;
-    param.ranges.min = -8.0f;
-    param.ranges.max = 8.0f;
-    param.ranges.step = 1.0f;
-    param.ranges.stepSmall = 1.0f;
-    param.ranges.stepLarge = 1.0f;
-    param.scalePointCount = 0;
-    param.scalePoints     = NULL;
-
-    return &param;
-
-    // unused
-    (void)handle;
+    static NativeParameter param[] =
+    {
+        {
+          .name  = "Octaves",
+          .unit  = NULL,
+          .hints = NATIVE_PARAMETER_IS_ENABLED|NATIVE_PARAMETER_IS_AUTOMABLE|NATIVE_PARAMETER_IS_INTEGER,
+          .ranges.def = 0.0f,
+          .ranges.min = -8.0f,
+          .ranges.max = 8.0f,
+          .ranges.step = 1.0f,
+          .ranges.stepSmall = 1.0f,
+          .ranges.stepLarge = 1.0f,
+          .scalePointCount = 0,
+          .scalePoints     = NULL,
+        },
+        {
+          .name  = "Semitones",
+          .unit  = NULL,
+          .hints = NATIVE_PARAMETER_IS_ENABLED|NATIVE_PARAMETER_IS_AUTOMABLE|NATIVE_PARAMETER_IS_INTEGER,
+          .ranges.def = 0.0f,
+          .ranges.min = -12.0f,
+          .ranges.max = 12.0f,
+          .ranges.step = 1.0f,
+          .ranges.stepSmall = 1.0f,
+          .ranges.stepLarge = 1.0f,
+          .scalePointCount = 0,
+          .scalePoints     = NULL,
+        },
+    };
+    return &param[index];
 }
 
 static float miditranspose_get_parameter_value(NativePluginHandle handle, uint32_t index)
 {
-    if (index != 0)
+    switch (index)
+    {
+        case 0:
+        return (float)handlePtr->octaves;
+        case 1:
+        return (float)handlePtr->semitones;
+        default:
         return 0.0f;
-
-    return (float)handlePtr->octaves;
+    }
 }
 
 static void miditranspose_set_parameter_value(NativePluginHandle handle, uint32_t index, float value)
 {
-    if (index != 0)
-        return;
+  switch (index)
+  {
+      case 0:
+      handlePtr->octaves = (int)value;
+      case 1:
+      handlePtr->semitones = (int)value;
+      default:
+      return;
+  }
 
-    handlePtr->octaves = (int)value;
 }
 
 static void miditranspose_process(NativePluginHandle handle, float** inBuffer, float** outBuffer, uint32_t frames, const NativeMidiEvent* midiEvents, uint32_t midiEventCount)
 {
     const NativeHostDescriptor* const host = handlePtr->host;
     const int octaves = handlePtr->octaves;
-    NativeMidiEvent tmpEvent;
+    const int semitones = handlePtr->semitones;
+        NativeMidiEvent tmpEvent;
 
     for (uint32_t i=0; i < midiEventCount; ++i)
     {
@@ -112,7 +139,7 @@ static void miditranspose_process(NativePluginHandle handle, float** inBuffer, f
         if (status == MIDI_STATUS_NOTE_OFF || status == MIDI_STATUS_NOTE_ON)
         {
             int oldnote = midiEvent->data[1];
-            int newnote = oldnote + octaves*12;
+            int newnote = oldnote + octaves*12 + semitones;
 
             if (newnote < 0 || newnote >= MAX_MIDI_NOTE)
                 continue;
@@ -151,7 +178,7 @@ static const NativePluginDescriptor miditransposeDesc = {
     .audioOuts = 0,
     .midiIns   = 1,
     .midiOuts  = 1,
-    .paramIns  = 1,
+    .paramIns  = 2,
     .paramOuts = 0,
     .name      = "MIDI Transpose",
     .label     = "miditranspose",

--- a/source/native-plugins/midi-transpose.c
+++ b/source/native-plugins/midi-transpose.c
@@ -112,17 +112,17 @@ static float miditranspose_get_parameter_value(NativePluginHandle handle, uint32
 
 static void miditranspose_set_parameter_value(NativePluginHandle handle, uint32_t index, float value)
 {
-  switch (index)
-  {
-      case 0:
-          handlePtr->octaves = (int)value;
-          break;
-      case 1:
-          handlePtr->semitones = (int)value;
-          break;
-      default:
-          return;
-  }
+    switch (index)
+    {
+        case 0:
+            handlePtr->octaves = (int)value;
+            break;
+        case 1:
+            handlePtr->semitones = (int)value;
+            break;
+        default:
+            return;
+    }
 
 }
 

--- a/source/native-plugins/midi-transpose.c
+++ b/source/native-plugins/midi-transpose.c
@@ -114,8 +114,10 @@ static void miditranspose_set_parameter_value(NativePluginHandle handle, uint32_
     {
         case 0:
             handlePtr->octaves = (int)value;
+            break;
         case 1:
             handlePtr->semitones = (int)value;
+            break;
         default:
             return;
     }

--- a/source/native-plugins/midi-transpose.c
+++ b/source/native-plugins/midi-transpose.c
@@ -131,7 +131,7 @@ static void miditranspose_process(NativePluginHandle handle, float** inBuffer, f
     const NativeHostDescriptor* const host = handlePtr->host;
     const int octaves = handlePtr->octaves;
     const int semitones = handlePtr->semitones;
-        NativeMidiEvent tmpEvent;
+    NativeMidiEvent tmpEvent;
 
     for (uint32_t i=0; i < midiEventCount; ++i)
     {


### PR DESCRIPTION
Works well both as internal and lv2 plugin.
Only issue is that the internal plugin still appears to only have 1 parameter from the "add plugin" window.
![image](https://user-images.githubusercontent.com/4637290/36869557-35bd9db2-1d6a-11e8-85a5-09d44d93c773.png)
