### PR TITLE
Do not use x86 asm with arm64

### DIFF
--- a/source/includes/CarlaDefines.h
+++ b/source/includes/CarlaDefines.h
@@ -60,7 +60,7 @@
 # define CARLA_OS_UNIX
 #endif
 
-#if defined (__LP64__) || defined (_LP64) || defined (__arm64__) || defined(CARLA_OS_WIN64)
+#if defined (__LP64__) || defined (_LP64) || defined (__arm64__) || defined (__aarch64__) || defined(CARLA_OS_WIN64)
 # define CARLA_OS_64BIT
 #endif
 

--- a/source/modules/water/memory/ByteOrder.h
+++ b/source/modules/water/memory/ByteOrder.h
@@ -153,7 +153,7 @@ inline uint32 ByteOrder::swap (uint32 n) noexcept
 {
    #ifdef CARLA_OS_MAC
     return OSSwapInt32 (n);
-   #elif defined(CARLA_OS_WIN) || ! (defined (__arm__) || defined (__arm64__))
+   #elif defined(CARLA_OS_WIN) || ! (defined (__arm__) || defined (__arm64__) || defined (__aarch64__))
     asm("bswap %%eax" : "=a"(n) : "a"(n));
     return n;
    #else


### PR DESCRIPTION
I don't know arm64 (or x86 asm) but the build does error with
```
../../modules/water/memory/ByteOrder.h:157:42: error: impossible constraint in 'asm'
     asm("bswap %%eax" : "=a"(n) : "a"(n));
```
which is probably a indication that this is not arm64 assembly :D