### PR TITLE
Only use GNU-specific char *strerror on systems with GLIBC

### DIFF
--- a/source/modules/hylia/link/asio/impl/error_code.ipp
+++ b/source/modules/hylia/link/asio/impl/error_code.ipp
@@ -101,7 +101,7 @@ public:
 #elif defined(__MACH__) && defined(__APPLE__) \
   || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__OpenBSD__) \
   || defined(_AIX) || defined(__hpux) || defined(__osf__) \
-  || defined(__ANDROID__)
+  || defined(__ANDROID__) || (defined(__linux__) && !defined(__GLIBC__))
     char buf[256] = "";
     using namespace std;
     strerror_r(value, buf, sizeof(buf));


### PR DESCRIPTION
`char *strerror_r(int errnum, char *buf, size_t buflen);` is only mostly not available on linux systems without GLIBC. (e.g. Alpine linux or Void Linux with musl)