### PR TITLE
Add X _NET_WM_WINDOW_TYPE flags to plugin windows 

### DIFF
--- a/source/utils/CarlaPluginUI.cpp
+++ b/source/utils/CarlaPluginUI.cpp
@@ -103,6 +103,15 @@ public:
         const Atom _nwi = XInternAtom(fDisplay, "_NET_WM_ICON", False);
         XChangeProperty(fDisplay, fHostWindow, _nwi, XA_CARDINAL, 32, PropModeReplace, (const uchar*)sCarlaX11Icon, sCarlaX11IconSize);
 
+        const Atom _wt = XInternAtom(fDisplay, "_NET_WM_WINDOW_TYPE", False);
+        // Setting the window to both dialog and normal will produce a decorated floating dialog
+        // Order is important: DIALOG needs to come before NORMAL
+        long _wtd = XInternAtom(fDisplay, "_NET_WM_WINDOW_TYPE_DIALOG", False);
+        XChangeProperty(fDisplay, fHostWindow, _wt, XA_ATOM, 32, PropModeReplace, (const uchar*) &_wtd, 1);
+        long _wtn = XInternAtom(fDisplay, "_NET_WM_WINDOW_TYPE_NORMAL", False);
+        XChangeProperty(fDisplay, fHostWindow, _wt, XA_ATOM, 32, PropModeAppend, (const uchar*) &_wtn, 1);
+
+
         if (parentId != 0)
             setTransientWinId(parentId);
     }


### PR DESCRIPTION
Add X _NET_WM_WINDOW_TYPE flags to plugin windows so they work equally well on tiling window manages and floating WM.

Tested with QTile 2869.95919912 and XFCE 4.12.1

I consider this a trivial change which will not create any copyright for me. 