### PR TITLE
Fixed shell export syntax

### DIFF
--- a/data/build-haiku.sh
+++ b/data/build-haiku.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 export HAIKU=true
 export CC=gcc-x86

--- a/data/carla
+++ b/data/carla
@@ -11,5 +11,6 @@ if [ "$1" = "--gdb" ]; then
 fi
 
 INSTALL_PREFIX="X-PREFIX-X"
-export PATH="$INSTALL_PREFIX"/lib/carla:$PATH
+PATH="$INSTALL_PREFIX"/lib/carla:$PATH
+export PATH
 exec $PYTHON "$INSTALL_PREFIX"/share/carla/carla --with-appname="$0" --with-libprefix="$INSTALL_PREFIX" "$@"

--- a/data/carla
+++ b/data/carla
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PYTHON=$(which python3 2>/dev/null)
 
@@ -11,6 +11,5 @@ if [ "$1" = "--gdb" ]; then
 fi
 
 INSTALL_PREFIX="X-PREFIX-X"
-PATH="$INSTALL_PREFIX"/lib/carla:$PATH
-export PATH
+export PATH="$INSTALL_PREFIX"/lib/carla:$PATH
 exec $PYTHON "$INSTALL_PREFIX"/share/carla/carla --with-appname="$0" --with-libprefix="$INSTALL_PREFIX" "$@"

--- a/data/carla-control
+++ b/data/carla-control
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PYTHON=$(which python3 2>/dev/null)
 

--- a/data/carla-database
+++ b/data/carla-database
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PYTHON=$(which python3 2>/dev/null)
 

--- a/data/carla-jack-multi
+++ b/data/carla-jack-multi
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PYTHON=$(which python3 2>/dev/null)
 

--- a/data/carla-jack-single
+++ b/data/carla-jack-single
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PYTHON=$(which python3 2>/dev/null)
 

--- a/data/carla-libdir
+++ b/data/carla-libdir
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # small script that only prints carla's libdir.
 # can be used to detect if carla is installed, and where to find its libcarla_standalone2.so file
 

--- a/data/carla-patchbay
+++ b/data/carla-patchbay
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PYTHON=$(which python3 2>/dev/null)
 

--- a/data/carla-rack
+++ b/data/carla-rack
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PYTHON=$(which python3 2>/dev/null)
 

--- a/data/carla-settings
+++ b/data/carla-settings
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PYTHON=$(which python3 2>/dev/null)
 


### PR DESCRIPTION
Previously, running Carla from this script would give the error, likely because the shell interpreter is not understand the more advanced syntax. Now uses simpler syntax.

`/usr/bin/carla: 14: export: Desktop:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin: bad variable name`

Note: Alternatively, to use the previous syntax, the script must be using #!/bin/bash
(Tested on Ubuntu 18.04.1)