### PR TITLE
Fix a build error on FreeBSD

### DIFF
--- a/source/bridges-plugin/CarlaBridgePlugin.cpp
+++ b/source/bridges-plugin/CarlaBridgePlugin.cpp
@@ -26,9 +26,12 @@
 #include "CarlaMainLoop.hpp"
 #include "CarlaMIDI.h"
 
+#ifdef CARLA_OS_UNIX
+# include <signal.h>
+#endif
+
 #ifdef CARLA_OS_LINUX
 # include <sched.h>
-# include <signal.h>
 # define SCHED_RESET_ON_FORK 0x40000000
 #endif
 


### PR DESCRIPTION
Include <signal.h> in order to make `kill`, `SIGKILL` available.