### PR TITLE
Change the dialog icon used for cancelable actions

### DIFF
--- a/source/frontend/carla_host.py
+++ b/source/frontend/carla_host.py
@@ -999,7 +999,7 @@ class HostWindow(QMainWindow):
 
         if started:
             self.fCancelableActionBox = QMessageBox(self)
-            self.fCancelableActionBox.setIcon(QMessageBox.Critical)
+            self.fCancelableActionBox.setIcon(QMessageBox.Information)
             self.fCancelableActionBox.setWindowTitle(self.tr("Action in progress"))
             self.fCancelableActionBox.setText(action)
             self.fCancelableActionBox.setInformativeText(self.tr("An action is in progress, please wait..."))


### PR DESCRIPTION
I find this icon :information_source: more fitting for the cancelable action, rather than using :x: which suggests error and it's a little confusing.