### PR TITLE
Fix segfault on PowerPC

### DIFF
--- a/source/jackbridge/JackBridge1.cpp
+++ b/source/jackbridge/JackBridge1.cpp
@@ -58,7 +58,7 @@ typedef void (JACKSYM_API *JackSymPropertyChangeCallback)(jack_uuid_t, const cha
 typedef void        (JACKSYM_API *jacksym_get_version)(int*, int*, int*, int*);
 typedef const char* (JACKSYM_API *jacksym_get_version_string)(void);
 
-typedef jack_client_t* (JACKSYM_API *jacksym_client_open)(const char*, jack_options_t, jack_status_t*);
+typedef jack_client_t* (JACKSYM_API *jacksym_client_open)(const char*, jack_options_t, jack_status_t*, ...);
 typedef int            (JACKSYM_API *jacksym_client_close)(jack_client_t*);
 
 typedef int   (JACKSYM_API *jacksym_client_name_size)(void);


### PR DESCRIPTION
The type of `JackBridge::client_open_ptr` is:

    jack_client_t* (*)(const char*, jack_options_t, jack_status_t*)

`client_open_ptr` is set to the address of `jack_client_open` (loaded via `dlopen`/`dlsym`), but the signature of `jack_client_open` is:

    jack_client_t* jack_client_open(const char*, jack_options_t, jack_status_t*, ...)

`jack_client_open` is variadic, while `client_open_ptr` is not. PowerPC segfaults when calling a variadic function through a non-variadic pointer, as PowerPC reserves different amounts of stack space when calling a variadic vs. non-variadic function. In this case, `jack_client_open` assumes the caller allocated more space than it actually did, so it overwrites parts of the caller's stack frame that were not intended to be modified.

This PR changes the type of `JackBridge::client_open_ptr` to match the signature of `jack_client_open`.

I've verified the issue and tested this fix on ppc64le Debian testing.