### PR TITLE
Fix source comment and user facing typos

### DIFF
--- a/resources/bitmaps/keyboard/export.sh
+++ b/resources/bitmaps/keyboard/export.sh
@@ -35,7 +35,7 @@ done
 # pngcrush creates the dir given for -d, if necessary.
 pngcrush -c 2 -reduce -d crushed white_*.png
 
-# Optimze transparent images, keeping their alpha channels:
+# Optimize transparent images, keeping their alpha channels:
 pngcrush -c 6 -reduce -d crushed black_*.png
 
 # Cleanup:

--- a/resources/bitmaps/keyboard/join.sh
+++ b/resources/bitmaps/keyboard/join.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Join images vertically, to create a sprite sheat.
+# Join images vertically, to create a sprite sheet.
 # Dependencies: Imagemagick (convert)
 
 convert white_bright_normal.png \

--- a/resources/ui/carla_settings.ui
+++ b/resources/ui/carla_settings.ui
@@ -2076,7 +2076,7 @@
             <item row="2" column="0" colspan="2">
              <widget class="QLabel" name="label_30">
               <property name="text">
-               <string>Note: WINEPREFIX env var is prefered over this fallback</string>
+               <string>Note: WINEPREFIX env var is preferred over this fallback</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignCenter</set>

--- a/source/backend/CarlaBackend.h
+++ b/source/backend/CarlaBackend.h
@@ -74,7 +74,7 @@ static const uint MAX_DEFAULT_PARAMETERS = 200;
 
 /*!
  * The "plugin Id" for the global Carla instance.
- * Curently only used for audio peaks.
+ * Currently only used for audio peaks.
  */
 static const uint MAIN_CARLA_PLUGIN_ID = 0xFFFF;
 
@@ -600,7 +600,7 @@ typedef enum {
     PARAMETER_INPUT = 1,
 
     /*!
-     * Ouput parameter.
+     * Output parameter.
      */
     PARAMETER_OUTPUT = 2
 

--- a/source/backend/CarlaEngine.hpp
+++ b/source/backend/CarlaEngine.hpp
@@ -587,7 +587,7 @@ protected:
 /*!
  * Carla Engine client.
  * Each plugin requires one client from the engine (created via CarlaEngine::addClient()).
- * @note This is a virtual class, some engine types provide custom funtionality.
+ * @note This is a virtual class, some engine types provide custom functionality.
  */
 class CARLA_API CarlaEngineClient
 {
@@ -768,7 +768,7 @@ public:
 
     /*!
      * Initialize/start the engine, using @a clientName.
-     * When the engine is intialized, you need to call idle() at regular intervals.
+     * When the engine is initialized, you need to call idle() at regular intervals.
      */
     virtual bool init(const char* const clientName) = 0;
 
@@ -971,7 +971,7 @@ public:
     const char* getName() const noexcept;
 
     /*!
-     * Get the current engine proccess mode.
+     * Get the current engine process mode.
      */
     EngineProcessMode getProccessMode() const noexcept;
 

--- a/source/backend/CarlaHost.h
+++ b/source/backend/CarlaHost.h
@@ -128,7 +128,7 @@ typedef struct _CarlaPluginInfo {
 
     /*!
      * Plugin unique Id.
-     * This Id is dependant on the plugin type and may sometimes be 0.
+     * This Id is dependent on the plugin type and may sometimes be 0.
      */
     int64_t uniqueId;
 

--- a/source/backend/CarlaPlugin.hpp
+++ b/source/backend/CarlaPlugin.hpp
@@ -584,7 +584,7 @@ public:
      * If @a key already exists, its current value will be swapped with @a value.
      *
      * @param type Type of data used in @a value.
-     * @param key A key identifing this data set.
+     * @param key A key identifying this data set.
      * @param value The value of the data set, of type @a type.
      * @param sendGui Send message change to plugin's custom GUI, if any
      *

--- a/source/backend/CarlaStandalone.cpp
+++ b/source/backend/CarlaStandalone.cpp
@@ -333,7 +333,7 @@ bool carla_engine_init(const char* driverName, const char* clientName)
 #endif
 
     CarlaEngine* const engine = CarlaEngine::newDriverByName(driverName);
-    CARLA_SAFE_ASSERT_WITH_LAST_ERROR_RETURN(engine != nullptr, "The seleted audio driver is not available", false);
+    CARLA_SAFE_ASSERT_WITH_LAST_ERROR_RETURN(engine != nullptr, "The selected audio driver is not available", false);
 
     gStandalone.engine = engine;
 
@@ -404,7 +404,7 @@ bool carla_engine_init_bridge(const char audioBaseName[6+1], const char rtClient
                                                              nonRtClientBaseName,
                                                              nonRtServerBaseName));
 
-    CARLA_SAFE_ASSERT_WITH_LAST_ERROR_RETURN(engine != nullptr, "The seleted audio driver is not available", false);
+    CARLA_SAFE_ASSERT_WITH_LAST_ERROR_RETURN(engine != nullptr, "The selected audio driver is not available", false);
 
     engine->setOption(CB::ENGINE_OPTION_PROCESS_MODE,   CB::ENGINE_PROCESS_MODE_BRIDGE,   nullptr);
     engine->setOption(CB::ENGINE_OPTION_TRANSPORT_MODE, CB::ENGINE_TRANSPORT_MODE_BRIDGE, nullptr);

--- a/source/backend/engine/CarlaEngineData.cpp
+++ b/source/backend/engine/CarlaEngineData.cpp
@@ -412,7 +412,7 @@ bool EngineTimeInfo::compareIgnoringRollingFrames(const EngineTimeInfo& timeInfo
     if (frame > timeInfo.frame)
         return false;
 
-    // not playing, so dont bother checking transport
+    // not playing, so don't bother checking transport
     // assume frame changed, likely playback has stopped
     if (! playing)
         return false;

--- a/source/backend/plugin/CarlaPluginVST2.cpp
+++ b/source/backend/plugin/CarlaPluginVST2.cpp
@@ -2672,7 +2672,7 @@ private:
             return kVstLangEnglish;
         }
 
-        // Check if 'resvd1' points to us, otherwise register ourselfs if possible
+        // Check if 'resvd1' points to us, otherwise register ourselves if possible
         CarlaPluginVST2* self = nullptr;
 
         if (effect != nullptr)

--- a/source/bridges-plugin/CarlaBridgePlugin.cpp
+++ b/source/bridges-plugin/CarlaBridgePlugin.cpp
@@ -265,7 +265,7 @@ public:
             if (File(gProjectFilename).existsAsFile())
             {
                 if (carla_load_plugin_state(0, gProjectFilename.toRawUTF8()))
-                    carla_stdout("Plugin state loaded sucessfully");
+                    carla_stdout("Plugin state loaded successfully");
                 else
                     carla_stderr("Plugin state load failed, error was:\n%s", carla_get_last_error());
             }

--- a/source/frontend/carla_backend.py
+++ b/source/frontend/carla_backend.py
@@ -155,7 +155,7 @@ MAX_PATCHBAY_PLUGINS = 255
 MAX_DEFAULT_PARAMETERS = 200
 
 # The "plugin Id" for the global Carla instance.
-# Curently only used for audio peaks.
+# Currently only used for audio peaks.
 MAIN_CARLA_PLUGIN_ID = 0xFFFF
 
 # ------------------------------------------------------------------------------------------------------------
@@ -455,7 +455,7 @@ PARAMETER_UNKNOWN = 0
 # Input parameter.
 PARAMETER_INPUT = 1
 
-# Ouput parameter.
+# Output parameter.
 PARAMETER_OUTPUT = 2
 
 # ------------------------------------------------------------------------------------------------------------
@@ -1172,7 +1172,7 @@ class CarlaPluginInfo(Structure):
         ("iconName", c_char_p),
 
         # Plugin unique Id.
-        # This Id is dependant on the plugin type and may sometimes be 0.
+        # This Id is dependent on the plugin type and may sometimes be 0.
         ("uniqueId", c_int64)
     ]
 

--- a/source/frontend/carla_control.py
+++ b/source/frontend/carla_control.py
@@ -59,7 +59,7 @@ class ConnectDialog(QDialog):
 
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
 
-        # Mke PlainTextEdit background the same color as the window background
+        # Make PlainTextEdit background the same color as the window background
         palette = self.ui.te_reported_hint.palette()
         palette.setColor(QPalette.Base, palette.color(QPalette.Background))
         self.ui.te_reported_hint.setPalette(palette)

--- a/source/frontend/carla_skin.py
+++ b/source/frontend/carla_skin.py
@@ -41,8 +41,8 @@ from widgets.pixmapdial import PixmapDial
 
 # Base is a QFrame (NoFrame, Plain, 0-size lines), with "PluginWidget" as object name.
 # Spacing of the top-most layout must be 1px.
-# Top and bottom margins must be 3px (can be splitted between different qt layouts).
-# Left and right margins must be 6px (can be splitted between different qt layouts).
+# Top and bottom margins must be 3px (can be split between different Qt layouts).
+# Left and right margins must be 6px (can be split between different Qt layouts).
 # If the left or right side has built-in margins, say a transparent png border,
 # those margins must be taken into consideration.
 #

--- a/source/frontend/patchcanvas.py
+++ b/source/frontend/patchcanvas.py
@@ -608,7 +608,7 @@ def splitGroup(group_id):
     for group in canvas.group_list:
         if group.group_id == group_id:
             if group.split:
-                qCritical("PatchCanvas::splitGroup(%i) - group is already splitted" % group_id)
+                qCritical("PatchCanvas::splitGroup(%i) - group is already split" % group_id)
                 return
 
             item = group.widgets[0]
@@ -656,7 +656,7 @@ def splitGroup(group_id):
 
     removeGroup(group_id)
 
-    # Step 3 - Re-create Item, now splitted
+    # Step 3 - Re-create Item, now split
     addGroup(group_id, group_name, SPLIT_YES, group_icon)
 
     if plugin_id >= 0:
@@ -687,7 +687,7 @@ def joinGroup(group_id):
     for group in canvas.group_list:
         if group.group_id == group_id:
             if not group.split:
-                qCritical("PatchCanvas::joinGroup(%i) - group is not splitted" % group_id)
+                qCritical("PatchCanvas::joinGroup(%i) - group is not split" % group_id)
                 return
 
             item = group.widgets[0]

--- a/source/frontend/patchcanvas/canvasport.py
+++ b/source/frontend/patchcanvas/canvasport.py
@@ -233,7 +233,7 @@ class CanvasPort(QGraphicsItem):
                     hover_group_id = self.m_hover_item.getGroupId()
                     hover_port_id = self.m_hover_item.getPortId()
 
-                    # FIXME clean ths big if stuff
+                    # FIXME clean this big if stuff
                     if (
                         (connection.group_out_id == self.m_group_id and
                          connection.port_out_id == self.m_port_id and

--- a/source/frontend/patchcanvas/patchcanvas.py
+++ b/source/frontend/patchcanvas/patchcanvas.py
@@ -423,7 +423,7 @@ def splitGroup(group_id):
     for group in canvas.group_list:
         if group.group_id == group_id:
             if group.split:
-                qCritical("PatchCanvas::splitGroup(%i) - group is already splitted" % group_id)
+                qCritical("PatchCanvas::splitGroup(%i) - group is already split" % group_id)
                 return
 
             item = group.widgets[0]
@@ -472,7 +472,7 @@ def splitGroup(group_id):
 
     removeGroup(group_id)
 
-    # Step 3 - Re-create Item, now splitted
+    # Step 3 - Re-create Item, now split
     addGroup(group_id, group_name, SPLIT_YES, group_icon)
 
     if plugin_id >= 0:
@@ -504,7 +504,7 @@ def joinGroup(group_id):
     for group in canvas.group_list:
         if group.group_id == group_id:
             if not group.split:
-                qCritical("PatchCanvas::joinGroup(%i) - group is not splitted" % group_id)
+                qCritical("PatchCanvas::joinGroup(%i) - group is not split" % group_id)
                 return
 
             item = group.widgets[0]

--- a/source/interposer/interposer-jack-x11.cpp
+++ b/source/interposer/interposer-jack-x11.cpp
@@ -346,7 +346,7 @@ int XNextEvent(Display* display, XEvent* event)
         gInterposedCallback(LIBJACK_INTERPOSER_CALLBACK_UI_HIDE, nullptr);
 
     event->type = 0;
-    carla_stdout("XNextEvent close event catched, hiding UI instead");
+    carla_stdout("XNextEvent close event caught, hiding UI instead");
     return real_XUnmapWindow(display, gCurrentlyMappedWindow);
 }
 

--- a/source/jackbridge/JackBridge1.cpp
+++ b/source/jackbridge/JackBridge1.cpp
@@ -415,7 +415,7 @@ struct JackBridge {
         }
         else
         {
-            fprintf(stdout, "%s loaded sucessfully!\n", filename);
+            fprintf(stdout, "%s loaded successfully!\n", filename);
         }
 
         #define JOIN(a, b) a ## b

--- a/source/libjack/libjack.cpp
+++ b/source/libjack/libjack.cpp
@@ -665,7 +665,7 @@ bool CarlaJackAppClient::handleRtData()
 
                 if (! fClients.isEmpty())
                 {
-                    // save tranport for all clients
+                    // save transport for all clients
                     const BridgeTimeInfo& bridgeTimeInfo(fShmRtClientControl.data->timeInfo);
 
                     fServer.playing        = bridgeTimeInfo.playing;
@@ -755,7 +755,7 @@ bool CarlaJackAppClient::handleRtData()
                             // location to start of audio outputs
                             float* const fdataCopyOuts = fdataCopy;
 
-                            // set audio ouputs
+                            // set audio outputs
                             i = 0;
                             for (LinkedList<JackPortState*>::Itenerator it2 = jclient->audioOuts.begin2(); it2.valid(); it2.next())
                             {

--- a/source/libjack/libjack_midi.cpp
+++ b/source/libjack/libjack_midi.cpp
@@ -89,7 +89,7 @@ jack_midi_data_t* jack_midi_event_reserve(void* buf, jack_nframes_t frame, size_
     CARLA_SAFE_ASSERT_RETURN(jbasebuf->isValid, nullptr);
     CARLA_SAFE_ASSERT_RETURN(size < JackMidiPortBufferBase::kMaxEventSize, nullptr);
 
-    // broken jack applicatons, wow...
+    // broken jack applications, wow...
     if (size == 0)
         return nullptr;
 
@@ -117,7 +117,7 @@ int jack_midi_event_write(void* buf, jack_nframes_t frame, const jack_midi_data_
     CARLA_SAFE_ASSERT_RETURN(jbasebuf->isValid, EINVAL);
     CARLA_SAFE_ASSERT_RETURN(size < JackMidiPortBufferBase::kMaxEventSize, ENOBUFS);
 
-    // broken jack applicatons, wow...
+    // broken jack applications, wow...
     if (size == 0)
         return EINVAL;
 

--- a/source/theme/CarlaStyle.cpp
+++ b/source/theme/CarlaStyle.cpp
@@ -1355,7 +1355,7 @@ void CarlaStyle::drawControl(ControlElement element, const QStyleOption *option,
         break;
     case CE_Splitter:
     {
-        // Dont draw handle for single pixel splitters
+        // Don't draw handle for single pixel splitters
         if (option->rect.width() > 1 && option->rect.height() > 1) {
             //draw grips
             if (option->state & State_Horizontal) {
@@ -3047,7 +3047,7 @@ void CarlaStyle::drawComplexControl(ComplexControl control, const QStyleOptionCo
                     buttonOption.QStyleOption::operator=(*comboBox);
                     buttonOption.rect = rect;
                     buttonOption.state = (comboBox->state & (State_Enabled | State_MouseOver | State_HasFocus))
-                            | State_KeyboardFocusChange; // Allways show hig
+                            | State_KeyboardFocusChange; // Always show hig
 
                     if (sunken) {
                         buttonOption.state |= State_Sunken;

--- a/source/utils/CarlaJuceUtils.hpp
+++ b/source/utils/CarlaJuceUtils.hpp
@@ -184,7 +184,7 @@ private:
     can use the release() method.
 
     Something to note is the main difference between this class and the std::auto_ptr class,
-    which is that ScopedPointer provides a cast-to-object operator, wheras std::auto_ptr
+    which is that ScopedPointer provides a cast-to-object operator, whereas std::auto_ptr
     requires that you always call get() to retrieve the pointer. The advantages of providing
     the cast is that you don't need to call get(), so can use the ScopedPointer in pretty much
     exactly the same way as a raw pointer. The disadvantage is that the compiler is free to

--- a/source/utils/CarlaLv2Utils.hpp
+++ b/source/utils/CarlaLv2Utils.hpp
@@ -1908,7 +1908,7 @@ const LV2_RDF_Descriptor* lv2_rdf_new(const LV2_URI uri, const bool loadPresets)
                     rdfPort->Types |= LV2_PORT_DATA_MIDI_EVENT;
                 }
                 else
-                    carla_stderr("lv2_rdf_new(\"%s\") - port '%s' is of unkown data type", uri, rdfPort->Name);
+                    carla_stderr("lv2_rdf_new(\"%s\") - port '%s' is of unknown data type", uri, rdfPort->Name);
             }
 
             // --------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Found via `codepell` (v1.17.0.dev0)  
```
codespell -q 3 -L iff,iif,inport,sord,sinc,te,uint -S ./source/includes,./source/modules,./source/native-plugins,./data/windows
```