### PR TITLE
fix missing - from rpath in pc files

### DIFF
--- a/data/carla-native-plugin.pc
+++ b/data/carla-native-plugin.pc
@@ -5,5 +5,5 @@ includedir=X-INCLUDEDIR-X/carla
 Name: carla-native-plugin
 Version: 1.9.14
 Description: Carla Native Plugin
-Libs: -Wl,rpath=${libdir} -L${libdir} -lcarla_native-plugin
+Libs: -Wl,-rpath=${libdir} -L${libdir} -lcarla_native-plugin
 Cflags: -DREAL_BUILD -I${includedir} -I${includedir}/includes

--- a/data/carla-standalone.pc
+++ b/data/carla-standalone.pc
@@ -5,5 +5,5 @@ includedir=X-INCLUDEDIR-X/carla
 Name: carla-standalone
 Version: 1.9.14
 Description: Carla Host Standalone
-Libs: -Wl,rpath=${libdir} -L${libdir} -lcarla_standalone2
+Libs: -Wl,-rpath=${libdir} -L${libdir} -lcarla_standalone2
 Cflags: -DREAL_BUILD -I${includedir} -I${includedir}/includes

--- a/data/carla-utils.pc
+++ b/data/carla-utils.pc
@@ -5,5 +5,5 @@ includedir=X-INCLUDEDIR-X/carla
 Name: carla-utils
 Version: 1.9.14
 Description: Carla Host Utilities
-Libs: -Wl,rpath=${libdir} -L${libdir} -lcarla_utils
+Libs: -Wl,-rpath=${libdir} -L${libdir} -lcarla_utils
 Cflags: -DREAL_BUILD -I${includedir} -I${includedir}/includes -I${includedir}/utils


### PR DESCRIPTION
from IRC
```
<alextee> falktx, i get "/usr/bin/ld: cannot find rpath=/usr/lib/carla: No such file or directory" when using carla-native-plugin from pkgconfig
...
<alextee> falktx, i asked in #mesonbuild and it looks like the --libs of carla-native-plugin is wrong
<alextee> it currently says: -Wl,rpath=/usr/lib/carla -L/usr/lib/carla -lcarla_native-plugin
<alextee> but i was told it should be "-Wl,-rpath,/usr/lib/carla"
```

using `-Wl,-rpath,...` instead of `-Wl,rpath=...` made by build succeed

I think the problem is not the `=` but the missing `-` before rpath:
https://stackoverflow.com/a/15667612

EDIT:
changed to `-Wl,-rpath=dir`