### PR TITLE
Canvas pairs

### DIFF
--- a/source/frontend/patchcanvas.py
+++ b/source/frontend/patchcanvas.py
@@ -270,11 +270,12 @@ class CanvasObject(QObject):
     @pyqtSlot()
     def PortContextMenuDisconnect(self):
         try:
-            connectionId = int(self.sender().data())
+            connectionId_list = self.sender().data()
         except:
             return
-
-        CanvasCallback(ACTION_PORTS_DISCONNECT, connectionId, 0, "")
+        
+        for connectionId in connectionId_list:
+            CanvasCallback(ACTION_PORTS_DISCONNECT, connectionId, 0, "")
         
     @pyqtSlot()
     def SetasStereoWith(self):
@@ -293,6 +294,7 @@ canvas.qobject    = None
 canvas.settings   = None
 canvas.theme      = None
 canvas.initiated  = False
+canvas.is_line_mov = False
 canvas.group_list = []
 canvas.port_list  = []
 canvas.pair_list  = []
@@ -1556,9 +1558,9 @@ def CanvasSplitPair(pair_id):
             pair_ports_names.append(port.port_name)
             #full_port_name = CanvasGetFullPortName(port.port_id)
             group_name = CanvasGetGroupName(port.group_id)
-            if options.stereo_detection:
-                canvas.settings.setValue("ForcedMonoPorts/%s:%s" % (group_name, port.port_name), port.port_mode)
-            canvas.callback(ACTION_SAVE_MONO_PORT, port.port_id, port.port_mode, group_name + ':' + port.port_name)
+            #if options.stereo_detection:
+                #canvas.settings.setValue("ForcedMonoPorts/%s:%s" % (group_name, port.port_name), port.port_mode)
+            #canvas.callback(ACTION_SAVE_MONO_PORT, port.port_id, port.port_mode, group_name + ':' + port.port_name)
             
             canvas.settings.beginGroup("CanvasPairs")
             all_pair_nums = canvas.settings.childKeys()
@@ -2186,8 +2188,7 @@ class CanvasBezierLine(QGraphicsPathItem):
         if self.item1.getPortMode() == PORT_MODE_OUTPUT:
             item1_x = self.item1.scenePos().x() + self.item1.getPortWidth() + 12
             
-            pppl1 = CanvasGetPortPositionAndPairLenght(self.item1.getPortId(), self.item1.getPairId())
-            port_posinpair1, pair_lenght1 = pppl1[0], pppl1[1]
+            port_posinpair1, pair_lenght1 = CanvasGetPortPositionAndPairLenght(self.item1.getPortId(), self.item1.getPairId())
             
             if pair_lenght1 > 2:
                 phi = 0.75
@@ -2204,17 +2205,14 @@ class CanvasBezierLine(QGraphicsPathItem):
             
             item1_y = self.item1.scenePos().y() + old_y1
             
-            
             item2_x = self.item2.scenePos().x()
             
-            pppl2 = CanvasGetPortPositionAndPairLenght(self.item2.getPortId(), self.item2.getPairId())
-            port_posinpair2, pair_lenght2 = pppl2[0], pppl2[1]
+            port_posinpair2, pair_lenght2 = CanvasGetPortPositionAndPairLenght(self.item2.getPortId(), self.item2.getPairId())
             
             if pair_lenght2 > 2:
                 phi = 0.75
             else:
                 phi = 0.62
-            
             
             if pair_lenght2 > 1:
                 first_old_y = canvas.theme.port_height * phi
@@ -2232,42 +2230,42 @@ class CanvasBezierLine(QGraphicsPathItem):
             item2_mid_x = abs(item1_x - item2_x) / 2
             item2_new_x = item2_x - item2_mid_x
             
-            if 0 == 0:
-                item1_new_y, item2_new_y = item1_y, item2_y
-                addLine = False
+            #if 0 == 0:
+                #item1_new_y, item2_new_y = item1_y, item2_y
+                #addLine = False
                 
-                diffxy = abs(item1_y - item2_y) - 1 * (abs(item1_x - item2_x))
-                if diffxy > 0:
-                    if abs(item1_y - item2_y) > 50:
-                        item1_new_x += abs(diffxy)
-                        item2_new_x -= abs(diffxy)
+                #diffxy = abs(item1_y - item2_y) - 1 * (abs(item1_x - item2_x))
+                #if diffxy > 0:
+                    #if abs(item1_y - item2_y) > 50:
+                        #item1_new_x += abs(diffxy)
+                        #item2_new_x -= abs(diffxy)
 
-                    if abs(item1_y - item2_y) > 50:
-                        while abs(item1_new_x - item2_x) < 50:
-                            item1_new_x += 10
-                            item2_new_x -= 10
+                    #if abs(item1_y - item2_y) > 50:
+                        #while abs(item1_new_x - item2_x) < 50:
+                            #item1_new_x += 10
+                            #item2_new_x -= 10
                     
                     
                     
-                if item1_x - item2_x > 0:
-                    if item1_new_x - item1_x < 80:
-                        item1_new_x = item1_x + 80
-                        item2_new_x = item2_x - 80
-                    elif item1_new_x - item1_x > 300:
-                        item1_new_x = item1_x + 300
-                        item2_new_x = item2_x - 300
+                #if item1_x - item2_x > 0:
+                    #if item1_new_x - item1_x < 80:
+                        #item1_new_x = item1_x + 80
+                        #item2_new_x = item2_x - 80
+                    #elif item1_new_x - item1_x > 300:
+                        #item1_new_x = item1_x + 300
+                        #item2_new_x = item2_x - 300
                         
-                    #correction de la ligne droite
-                    diff_y = abs(item1_y - item2_y)
-                    if diff_y <= 200:
-                        if diff_y < 5:
-                            diff_y = 5
-                        item1_new_y -= 50 / (log(diff_y) *log(diff_y))
-                        item2_new_y += 50 / (log(diff_y) * log(diff_y))
+                    ##correction de la ligne droite
+                    #diff_y = abs(item1_y - item2_y)
+                    #if diff_y <= 200:
+                        #if diff_y < 5:
+                            #diff_y = 5
+                        #item1_new_y -= 50 / (log(diff_y) *log(diff_y))
+                        #item2_new_y += 50 / (log(diff_y) * log(diff_y))
             
             path = QPainterPath(QPointF(item1_x, item1_y))
-            path.cubicTo(item1_new_x, item1_new_y, item2_new_x, item2_new_y, item2_x, item2_y)
-            #path.cubicTo(item1_new_x, item1_y, item2_new_x, item2_y, item2_x, item2_y)
+            #path.cubicTo(item1_new_x, item1_new_y, item2_new_x, item2_new_y, item2_x, item2_y)
+            path.cubicTo(item1_new_x, item1_y, item2_new_x, item2_y, item2_x, item2_y)
             self.setPath(path)
 
             self.m_lineSelected = False
@@ -2363,6 +2361,9 @@ class CanvasLineMov(QGraphicsLineItem):
     
     def setReadyToDisc(self, yesno):
         self.m_ready_to_disc = yesno
+    
+    def toggleReadyToDisc(self):
+        self.m_ready_to_disc = not bool(self.m_ready_to_disc)
     
     def updateLinePos(self, scenePos):
         if self.m_ready_to_disc:
@@ -2492,6 +2493,9 @@ class CanvasBezierLineMov(QGraphicsPathItem):
     
     def setReadyToDisc(self, yesno):
         self.m_ready_to_disc = yesno
+    
+    def toggleReadyToDisc(self):
+        self.m_ready_to_disc = not bool(self.m_ready_to_disc)
     
     def setPortPosInPairTo(self, port_posinpair_to):
         self.m_port_posinpair_to = port_posinpair_to
@@ -2635,6 +2639,7 @@ class CanvasPort(QGraphicsItem):
         self.m_port_font.setWeight(canvas.theme.port_font_state)
 
         self.m_line_mov_list = []
+        self.m_dotcon_list = []
         self.m_hover_item = None
         self.m_last_selected_state = False
 
@@ -2698,7 +2703,25 @@ class CanvasPort(QGraphicsItem):
 
         self.m_port_width = port_width
         self.update()
-
+    
+    def deleteLine2(self):
+        for line_mov in self.m_line_mov_list:
+            if self.m_line_mov_list.index(line_mov) > 0:
+                canvas.scene.removeItem(line_mov)
+            else:
+                line_mov.setPortPosInPairTo(PORT_IN_PAIR_POSITION_MONO)
+        self.m_line_mov_list = self.m_line_mov_list[:1]
+    
+    def resetDotLines(self):
+        for connection in self.m_dotcon_list:
+            if connection.widget.isReadyToDisc():
+                connection.widget.setReadyToDisc(False)
+                connection.widget.updateLineGradient()
+                
+        for line_mov in self.m_line_mov_list:
+            line_mov.setReadyToDisc(False)
+        self.m_dotcon_list.clear()
+    
     def SetAsStereo(self, port_id):
         port_id_list = []
         for port in canvas.port_list:
@@ -2732,7 +2755,43 @@ class CanvasPort(QGraphicsItem):
         #canvas.callback(ACTION_SAVE_PAIR, port_id_list.copy(), (self.m_port_mode, group_name, port_name_list), '')
         
         self.parentItem().updatePositions()
-        
+    
+    def connectToHover(self):
+        if self.m_hover_item:
+            if self.m_hover_item.type() == CanvasPortType:
+                hover_port_id_list = [ self.m_hover_item.getPortId() ]
+            elif self.m_hover_item.type() == CanvasStereoPairType:
+                hover_port_id_list = self.m_hover_item.getPortsList()
+                
+            con_list = []
+            ports_connected_list = []
+            
+            for port in canvas.port_list:
+                if port.port_id in hover_port_id_list:
+                    hover_group_id = port.group_id
+                    break
+            else:
+                return
+                    
+            for porthover_id in hover_port_id_list:
+                for connection in canvas.connection_list:
+                    if ( (connection.port_out_id == self.m_port_id and connection.port_in_id == porthover_id) or
+                         (connection.port_out_id == porthover_id and connection.port_in_id == self.m_port_id) ):
+                            con_list.append(connection)
+                            ports_connected_list.append(porthover_id)
+            
+            if len(con_list) == len(hover_port_id_list):
+                for connection in con_list:
+                    canvas.callback(ACTION_PORTS_DISCONNECT, connection.connection_id, 0, "")
+            else:
+                for porthover_id in hover_port_id_list:
+                    if not porthover_id in ports_connected_list:
+                        if self.m_port_mode == PORT_MODE_OUTPUT:
+                            conn = "%i:%i:%i:%i" % (self.m_group_id, self.m_port_id, hover_group_id, porthover_id) 
+                        else:
+                            conn = "%i:%i:%i:%i" % (hover_group_id, porthover_id, self.m_group_id, self.m_port_id)
+                        canvas.callback(ACTION_PORTS_CONNECT, '', '', conn)
+    
     def type(self):
         return CanvasPortType
 
@@ -2762,26 +2821,26 @@ class CanvasPort(QGraphicsItem):
                     if ((connection.group_out_id == self.m_group_id and connection.port_out_id == self.m_port_id) or
                         (connection.group_in_id  == self.m_group_id and connection.port_in_id  == self.m_port_id)):
                         connection.widget.setLocked(True)
-
-            port_posinpair, pair_lenght = CanvasGetPortPositionAndPairLenght(self.m_port_id, self.m_pair_id)
             
-            if options.use_bezier_lines:
-                line_mov = CanvasBezierLineMov(self.m_port_mode, self.m_port_type, port_posinpair, pair_lenght, self)
-            else:
-                line_mov = CanvasLineMov(self.m_port_mode, self.m_port_type, port_posinpair, pair_lenght, self)
-            
-            line_mov.setPortPosInPairTo(PORT_IN_PAIR_POSITION_MONO)
-            self.m_line_mov_list.append(line_mov)
-            canvas.is_line_mov = True
-            canvas.last_z_value += 1
-            line_mov.setZValue(canvas.last_z_value)
-            canvas.last_z_value += 1
-            self.parentItem().setZValue(canvas.last_z_value)
+            if not self.m_line_mov_list:
+                port_posinpair, pair_lenght = CanvasGetPortPositionAndPairLenght(self.m_port_id, self.m_pair_id)
+                
+                if options.use_bezier_lines:
+                    line_mov = CanvasBezierLineMov(self.m_port_mode, self.m_port_type, port_posinpair, pair_lenght, self)
+                else:
+                    line_mov = CanvasLineMov(self.m_port_mode, self.m_port_type, port_posinpair, pair_lenght, self)
+                
+                line_mov.setPortPosInPairTo(PORT_IN_PAIR_POSITION_MONO)
+                self.m_line_mov_list.append(line_mov)
+                canvas.is_line_mov = True
+                line_mov.setZValue(canvas.last_z_value)
+                canvas.last_z_value += 1
+                self.parentItem().setZValue(canvas.last_z_value)
 
             item = None
             items = canvas.scene.items(event.scenePos(), Qt.ContainsItemShape, Qt.AscendingOrder)
             for i in range(len(items)):
-                if items[i].type() == CanvasPortType:
+                if items[i].type() in (CanvasPortType, CanvasStereoPairType):
                     if items[i] != self:
                         if not item:
                             item = items[i]
@@ -2794,11 +2853,68 @@ class CanvasPort(QGraphicsItem):
             if item:
                 if item.getPortMode() != self.m_port_mode and item.getPortType() == self.m_port_type:
                     item.setSelected(True)
-                    self.m_hover_item = item
+                    if item.type() == CanvasStereoPairType:
+                        if self.m_hover_item != item:
+                            self.m_hover_item = item
+                            self.resetDotLines()
+                            
+                            if len(self.m_line_mov_list) <= 1:
+                                #make original line going to first port of the hover pair
+                                for line_mov in self.m_line_mov_list:
+                                    line_mov.setPortPosInPairTo(PORT_IN_PAIR_POSITION_LEFT)
+                                    line_mov.setPairLenghtTo(len(self.m_hover_item.m_port_id_list))
+                                    
+                                port_posinpair, pair_lenght = CanvasGetPortPositionAndPairLenght(self.m_port_id, self.m_pair_id)
+                                
+                                #create one line for each port of the hover pair
+                                for x in range(1, len(self.m_hover_item.m_port_id_list)):
+                                    if options.use_bezier_lines:
+                                        line_mov = CanvasBezierLineMov(self.m_port_mode, self.m_port_type, port_posinpair, pair_lenght, self)
+                                    else:
+                                        line_mov = CanvasLineMov(self.m_port_mode, self.m_port_type, port_posinpair, pair_lenght, self)
+                                    line_mov.setPortPosInPairTo(x)
+                                    line_mov.setPairLenghtTo(len(self.m_hover_item.m_port_id_list))
+                                    self.m_line_mov_list.append(line_mov)
+                                
+                            for port_id in self.m_hover_item.getPortsList():
+                                for connection in canvas.connection_list:
+                                    if ( (connection.port_out_id == self.m_port_id and connection.port_in_id == port_id) or
+                                        (connection.port_out_id == port_id and connection.port_in_id == self.m_port_id) ):
+                                        self.m_dotcon_list.append(connection)
+                                        
+                            if len(self.m_dotcon_list) == len(self.m_hover_item.getPortsList()):
+                                for connection in self.m_dotcon_list:
+                                    connection.widget.setReadyToDisc(True)
+                                    connection.widget.updateLineGradient()
+                                
+                                for line_mov in self.m_line_mov_list:
+                                    line_mov.setReadyToDisc(True)
+                        
+                    elif item.type() == CanvasPortType:
+                        if self.m_hover_item !=  item:
+                            self.m_hover_item = item
+                            self.deleteLine2()
+                            self.resetDotLines()
+                            
+                            for connection in canvas.connection_list:
+                                if ( (connection.port_out_id == self.m_port_id and connection.port_in_id == self.m_hover_item.getPortId()) or
+                                    (connection.port_out_id == self.m_hover_item.getPortId() and connection.port_in_id == self.m_port_id) ):
+                                    for line_mov in self.m_line_mov_list:
+                                        line_mov.setReadyToDisc(True)
+                                    connection.widget.setReadyToDisc(True)
+                                    connection.widget.updateLineGradient()
+                                    self.m_dotcon_list.append(connection)
+                                elif connection.widget.isReadyToDisc():
+                                    connection.widget.setReadyToDisc(False)
+                                    connection.widget.updateLineGradient()
                 else:
                     self.m_hover_item = None
+                    self.deleteLine2()
+                    self.resetDotLines()
             else:
                 self.m_hover_item = None
+                self.deleteLine2()
+                self.resetDotLines()
             
             for line_mov in self.m_line_mov_list:
                 line_mov.updateLinePos(event.scenePos())
@@ -2822,26 +2938,27 @@ class CanvasPort(QGraphicsItem):
                     connection.widget.setLocked(False)
 
             if self.m_hover_item:
-                # TODO: a better way to check already existing connection
-                for connection in canvas.connection_list:
-                    hover_group_id = self.m_hover_item.getGroupId()
-                    hover_port_id  = self.m_hover_item.getPortId()
+                ## TODO: a better way to check already existing connection
+                #for connection in canvas.connection_list:
+                    #hover_group_id = self.m_hover_item.getGroupId()
+                    #hover_port_id  = self.m_hover_item.getPortId()
 
-                    if (
-                        (connection.group_out_id == self.m_group_id and connection.port_out_id == self.m_port_id and
-                         connection.group_in_id  == hover_group_id  and connection.port_in_id  == hover_port_id) or
-                        (connection.group_out_id == hover_group_id  and connection.port_out_id == hover_port_id and
-                         connection.group_in_id  == self.m_group_id and connection.port_in_id  == self.m_port_id)
-                       ):
-                        canvas.callback(ACTION_PORTS_DISCONNECT, connection.connection_id, 0, "")
-                        break
-                else:
-                    if self.m_port_mode == PORT_MODE_OUTPUT:
-                        conn = "%i:%i:%i:%i" % (self.m_group_id, self.m_port_id, self.m_hover_item.getGroupId(), self.m_hover_item.getPortId())
-                        canvas.callback(ACTION_PORTS_CONNECT, 0, 0, conn)
-                    else:
-                        conn = "%i:%i:%i:%i" % (self.m_hover_item.getGroupId(), self.m_hover_item.getPortId(), self.m_group_id, self.m_port_id)
-                        canvas.callback(ACTION_PORTS_CONNECT, 0, 0, conn)
+                    #if (
+                        #(connection.group_out_id == self.m_group_id and connection.port_out_id == self.m_port_id and
+                         #connection.group_in_id  == hover_group_id  and connection.port_in_id  == hover_port_id) or
+                        #(connection.group_out_id == hover_group_id  and connection.port_out_id == hover_port_id and
+                         #connection.group_in_id  == self.m_group_id and connection.port_in_id  == self.m_port_id)
+                       #):
+                        #canvas.callback(ACTION_PORTS_DISCONNECT, connection.connection_id, 0, "")
+                        #break
+                #else:
+                    #if self.m_port_mode == PORT_MODE_OUTPUT:
+                        #conn = "%i:%i:%i:%i" % (self.m_group_id, self.m_port_id, self.m_hover_item.getGroupId(), self.m_hover_item.getPortId())
+                        #canvas.callback(ACTION_PORTS_CONNECT, 0, 0, conn)
+                    #else:
+                        #conn = "%i:%i:%i:%i" % (self.m_hover_item.getGroupId(), self.m_hover_item.getPortId(), self.m_group_id, self.m_port_id)
+                        #canvas.callback(ACTION_PORTS_CONNECT, 0, 0, conn)
+                self.connectToHover()
 
                 canvas.scene.clearSelection()
 
@@ -2866,7 +2983,7 @@ class CanvasPort(QGraphicsItem):
         if len(conn_list) > 0:
             for conn_id, group_id, port_id in conn_list:
                 act_x_disc = discMenu.addAction(CanvasGetFullPortName(group_id, port_id))
-                act_x_disc.setData(conn_id)
+                act_x_disc.setData([conn_id])
                 act_x_disc.triggered.connect(canvas.qobject.PortContextMenuDisconnect)
         else:
             act_x_disc = discMenu.addAction("No connections")
@@ -3103,6 +3220,7 @@ class CanvasStereoPair(QGraphicsItem):
         self.m_port_mode  = port_mode
         self.m_port_type  = port_type
         self.m_port_id_list = port_id_list
+        self.m_group_id = parent.getGroupId()
         
         # Base Variables
         self.m_pair_width  = 15
@@ -3131,6 +3249,9 @@ class CanvasStereoPair(QGraphicsItem):
 
     def getPortType(self):
         return self.m_port_type
+    
+    def getGroupId(self):
+        return self.m_group_id
     
     def getPortWidth(self):
         return self.m_pair_width
@@ -3322,7 +3443,6 @@ class CanvasStereoPair(QGraphicsItem):
                     item.setSelected(True)
                     if item.type() == CanvasPortType:
                         if self.m_hover_item != item:
-                            print(item.zValue(), item.parentItem().zValue())
                             self.m_hover_item = item
                             self.resetDotLines()
                             self.resetLineMovPositions()
@@ -3345,7 +3465,6 @@ class CanvasStereoPair(QGraphicsItem):
                                     
                     elif item.type() == CanvasStereoPairType:
                         if self.m_hover_item != item:
-                            print(item.zValue(), item.parentItem().zValue())
                             self.m_hover_item = item
                             self.resetDotLines()
                             self.resetLineMovPositions()
@@ -3477,9 +3596,8 @@ class CanvasStereoPair(QGraphicsItem):
         all_connected_ports_ids = []
         group_ids_list = []
         for selfport_id in self.m_port_id_list:
-            con_list = CanvasGetPortConnectionList(selfport_id)
-            for con_id in con_list:
-                port_id = CanvasGetConnectedPort(con_id, selfport_id)
+            con_list = CanvasGetPortConnectionList(self.m_group_id, selfport_id)
+            for con_id, group_id, port_id in con_list:
                 for port in canvas.port_list:
                     if port.port_id == port_id:
                         if not port.group_id in group_ids_list:
@@ -3592,7 +3710,7 @@ class CanvasStereoPair(QGraphicsItem):
                             last_is_dirty_pair = False
                             
                         #set port action in submenu (if port is not in a pair) 
-                        full_port_name = CanvasGetFullPortName(port.port_id)
+                        full_port_name = CanvasGetFullPortName(port.group_id, port.port_id)
                         act_x_disc_port = discMenu.addAction(full_port_name)
                         act_x_disc_port.setData(port_con_list)
                         act_x_disc_port.triggered.connect(canvas.qobject.PortContextMenuDisconnect)
@@ -4098,7 +4216,7 @@ class CanvasBox(QGraphicsItem):
         if len(conn_list) > 0:
             for conn_id, group_id, port_id in conn_list:
                 act_x_disc = discMenu.addAction(CanvasGetFullPortName(group_id, port_id))
-                act_x_disc.setData(conn_id)
+                act_x_disc.setData([conn_id])
                 act_x_disc.triggered.connect(canvas.qobject.PortContextMenuDisconnect)
         else:
             act_x_disc = discMenu.addAction("No connections")

--- a/source/frontend/patchcanvas.py
+++ b/source/frontend/patchcanvas.py
@@ -801,7 +801,7 @@ def joinGroup(group_id):
         setGroupAsPlugin(group_id, plugin_id, plugin_ui)
 
     for port in ports_data:
-        addPort(group_id, port.port_id, port.port_name, port.port_mode, port.port_type, port.pair_id, port.is_alternate)
+        addPort(group_id, port.port_id, port.port_name, port.port_mode, port.port_type, port.is_alternate)
 
     for conn in conns_data:
         connectPorts(conn.connection_id, conn.group_out_id, conn.port_out_id, conn.group_in_id, conn.port_in_id)
@@ -917,7 +917,7 @@ def setGroupAsPlugin(group_id, plugin_id, hasUi):
 
     qCritical("PatchCanvas::setGroupAsPlugin(%i, %i, %s) - unable to find group to set as plugin" % (group_id, plugin_id, bool2str(hasUi)))
 
-def addPort(group_id, port_id, port_name, port_mode, port_type, pair_id, is_alternate=False):
+def addPort(group_id, port_id, port_name, port_mode, port_type, is_alternate=False):
     if canvas.debug:
         print("PatchCanvas::addPort(%i, %i, %s, %s, %s, %s)" % (group_id, port_id, port_name.encode(), port_mode2str(port_mode), port_type2str(port_type), bool2str(is_alternate)))
 
@@ -936,7 +936,7 @@ def addPort(group_id, port_id, port_name, port_mode, port_type, pair_id, is_alte
             else:
                 n = 0
             box_widget  = group.widgets[n]
-            port_widget = box_widget.addPortFromGroup(port_id, port_mode, port_type, port_name, pair_id, is_alternate)
+            port_widget = box_widget.addPortFromGroup(port_id, port_mode, port_type, port_name, is_alternate)
             break
 
     if not (box_widget and port_widget):
@@ -949,7 +949,7 @@ def addPort(group_id, port_id, port_name, port_mode, port_type, pair_id, is_alte
     port_dict.port_name = port_name
     port_dict.port_mode = port_mode
     port_dict.port_type = port_type
-    port_dict.pair_id   = pair_id
+    port_dict.pair_id   = None
     port_dict.is_alternate = is_alternate
     port_dict.widget = port_widget
     canvas.port_list.append(port_dict)
@@ -4013,7 +4013,7 @@ class CanvasBox(QGraphicsItem):
         if self.shadow:
             self.shadow.setOpacity(opacity)
 
-    def addPortFromGroup(self, port_id, port_mode, port_type, port_name, pair_id, is_alternate):
+    def addPortFromGroup(self, port_id, port_mode, port_type, port_name, is_alternate):
         if len(self.m_port_list_ids) == 0:
             if options.auto_hide_groups:
                 if options.eyecandy == EYECANDY_FULL:

--- a/source/frontend/patchcanvas.py
+++ b/source/frontend/patchcanvas.py
@@ -955,7 +955,12 @@ def addPort(group_id, port_id, port_name, port_mode, port_type, is_alternate=Fal
     canvas.port_list.append(port_dict)
 
     box_widget.updatePositions()
-
+    
+    pair_port_id_list = CanvasGetNewPairPortIdList(group_id, port_id, port_name, port_mode, port_type)
+    if pair_port_id_list:
+        CanvasAddPair(group_id, port_mode, port_type, pair_port_id_list)
+    box_widget.updatePositions()
+    
     if options.eyecandy == EYECANDY_FULL:
         return CanvasItemFX(port_widget, True, False)
 
@@ -967,6 +972,8 @@ def removePort(group_id, port_id):
 
     for port in canvas.port_list:
         if port.group_id == group_id and port.port_id == port_id:
+            if port.pair_id:
+                CanvasRemovePair(port.pair_id)
             item = port.widget
             item.parentItem().removePortFromGroup(port_id)
             canvas.scene.removeItem(item)
@@ -1301,7 +1308,8 @@ def CanvasGetNewPairPortIdList(group_id, port_id, port_name, port_mode, port_typ
                 break
         
     #make stereo_detection
-    if options.stereo_detection:
+    #if options.stereo_detection:
+    if 0 == 1:
         if len(port_name) < 1:
             return
         

--- a/source/frontend/patchcanvas.py
+++ b/source/frontend/patchcanvas.py
@@ -715,7 +715,7 @@ def splitGroup(group_id):
         setGroupAsPlugin(group_id, plugin_id, plugin_ui)
 
     for port in ports_data:
-        addPort(group_id, port.port_id, port.port_name, port.port_mode, port.port_type, port.pair_id, port.is_alternate)
+        addPort(group_id, port.port_id, port.port_name, port.port_mode, port.port_type, port.is_alternate)
 
     for conn in conns_data:
         connectPorts(conn.connection_id, conn.group_out_id, conn.port_out_id, conn.group_in_id, conn.port_in_id)
@@ -2650,7 +2650,7 @@ class CanvasBezierLineMov(QGraphicsPathItem):
 # canvasport.cpp
 
 class CanvasPort(QGraphicsItem):
-    def __init__(self, group_id, port_id, port_name, port_mode, port_type, pair_id, is_alternate, parent):
+    def __init__(self, group_id, port_id, port_name, port_mode, port_type, is_alternate, parent):
         QGraphicsItem.__init__(self, parent)
 
         # Save Variables, useful for later
@@ -2659,7 +2659,7 @@ class CanvasPort(QGraphicsItem):
         self.m_port_mode = port_mode
         self.m_port_type = port_type
         self.m_port_name = port_name
-        self.m_pair_id   = pair_id
+        self.m_pair_id   = None
         self.m_is_alternate = is_alternate
 
         # Base Variables
@@ -4020,7 +4020,7 @@ class CanvasBox(QGraphicsItem):
                     CanvasItemFX(self, True, False)
                 self.setVisible(True)
 
-        new_widget = CanvasPort(self.m_group_id, port_id, port_name, port_mode, port_type, pair_id, is_alternate, self)
+        new_widget = CanvasPort(self.m_group_id, port_id, port_name, port_mode, port_type, is_alternate, self)
 
         port_dict = port_dict_t()
         port_dict.group_id = self.m_group_id

--- a/source/frontend/patchcanvas.py
+++ b/source/frontend/patchcanvas.py
@@ -2769,7 +2769,23 @@ class CanvasPort(QGraphicsItem):
 
         painter.setPen(text_pen)
         painter.setFont(self.m_port_font)
-        painter.drawText(text_pos, self.m_port_name)
+        
+        if self.m_pair_id:
+            print_name = CanvasGetPortPrintName(self.m_port_id, self.m_pair_id)
+            print_name_size = QFontMetrics(self.m_port_font).width(print_name)    
+            if self.m_port_mode == PORT_MODE_OUTPUT:
+                
+                text_pos = QPointF(self.m_port_width + 9 - print_name_size, canvas.theme.port_text_ypos) 
+
+            if print_name_size > (canvas.theme.port_in_pair_width - 6):
+                painter.setPen(QPen(poly_color, 3))
+                painter.drawLine(poly_locx[5], 3, poly_locx[5], canvas.theme.port_height - 3)
+                painter.setPen(text_pen)
+                painter.setFont(self.m_port_font)
+            painter.drawText(text_pos, print_name)
+            
+        else:
+            painter.drawText(text_pos, self.m_port_name)
 
         if self.isSelected() != self.m_last_selected_state:
             for connection in canvas.connection_list:
@@ -2806,7 +2822,10 @@ class CanvasStereoPair(QGraphicsItem):
         # Base Variables
         self.m_pair_width  = 15
         self.m_pair_height = canvas.theme.port_height
-        self.m_pair_font = QFont(canvas.theme.port_font_name, canvas.theme.port_font_size, canvas.theme.port_font_state)
+        self.m_pair_font = QFont()
+        self.m_pair_font.setFamily(canvas.theme.port_font_name)
+        self.m_pair_font.setPixelSize(canvas.theme.port_font_size)
+        self.m_pair_font.setWeight(canvas.theme.port_font_state)
 
         self.m_line_mov_list = []
         self.m_r_click_conn = None
@@ -3321,8 +3340,7 @@ class CanvasStereoPair(QGraphicsItem):
                 if port.port_id in self.m_port_id_list:
                     port_print_name = CanvasGetPortPrintName(port.port_id, self.m_pair_id)
                     port_in_p_width = QFontMetrics(self.m_pair_font).width(port_print_name) + 3
-                    if port_in_p_width > port_width:
-                        port_width = port_in_p_width
+                    port_width = max(port_width, port_in_p_width)
 
             text_pos = QPointF(port_width + 3, canvas.theme.port_text_ypos + (canvas.theme.port_height * (len(self.m_port_id_list) -1)/2))
 
@@ -3384,8 +3402,8 @@ class CanvasStereoPair(QGraphicsItem):
         polygon += QPointF(poly_locx[1], lineHinting)
         polygon += QPointF(poly_locx[2], float(canvas.theme.port_height / 2) )
         polygon += QPointF(poly_locx[2], float(canvas.theme.port_height * (len(self.m_port_id_list) - 1/2)) )
-        polygon += QPointF(poly_locx[3], canvas.theme.port_height * len(self.m_port_id_list))
-        polygon += QPointF(poly_locx[4], canvas.theme.port_height * len(self.m_port_id_list))
+        polygon += QPointF(poly_locx[3], canvas.theme.port_height * len(self.m_port_id_list) + lineHinting)
+        polygon += QPointF(poly_locx[4], canvas.theme.port_height * len(self.m_port_id_list) + lineHinting)
             
         if canvas.theme.port_bg_pixmap:
             portRect = polygon.boundingRect()

--- a/source/frontend/patchcanvas_theme.py
+++ b/source/frontend/patchcanvas_theme.py
@@ -108,6 +108,11 @@ class Theme(object):
             self.port_midi_alsa_bg_sel = QColor(64 + 50, 112 + 50, 18 + 50)
             self.port_parameter_bg = QColor(101, 47, 16)
             self.port_parameter_bg_sel = QColor(101 + 50, 47 + 50, 16 + 50)
+            
+            self.pair_audio_jack_pen = QPen(QColor(63, 90, 126), 1)
+            self.pair_audio_jack_pen_sel = QPen(QColor(63 + 30, 90 + 30, 126 + 30), 1)
+            self.pair_audio_jack_bg = QColor(26, 45, 71)
+            self.pair_audio_jack_bg_sel = QColor(27 + 50, 47 + 50, 75 + 50)
 
             self.port_audio_jack_text = self.port_text
             self.port_audio_jack_text_sel = self.port_text
@@ -117,7 +122,8 @@ class Theme(object):
             self.port_midi_alsa_text_sel = self.port_text
             self.port_parameter_text = self.port_text
             self.port_parameter_text_sel = self.port_text
-
+            
+            self.port_in_pair_width = 18
             self.port_height   = 16
             self.port_offset   = 0
             self.port_spacing  = 2
@@ -190,6 +196,11 @@ class Theme(object):
             self.port_midi_alsa_bg_sel = QColor(64 + 50, 112 + 50, 18 + 50)
             self.port_parameter_bg = QColor(101, 47, 16)
             self.port_parameter_bg_sel = QColor(101 + 50, 47 + 50, 16 + 50)
+            
+            self.pair_audio_jack_pen = QPen(QColor(63, 90, 126), 1)
+            self.pair_audio_jack_pen_sel = QPen(QColor(63 + 30, 90 + 30, 126 + 30), 1)
+            self.pair_audio_jack_bg = QColor(27, 47, 75)
+            self.pair_audio_jack_bg_sel = QColor(27 + 50, 47 + 50, 75 + 50)
 
             self.port_audio_jack_text = self.port_text
             self.port_audio_jack_text_sel = self.port_text
@@ -199,7 +210,8 @@ class Theme(object):
             self.port_midi_alsa_text_sel = self.port_text
             self.port_parameter_text = self.port_text
             self.port_parameter_text_sel = self.port_text
-
+            
+            self.port_in_pair_width = 15
             self.port_height   = 12
             self.port_offset   = 0
             self.port_spacing  = 1
@@ -272,6 +284,11 @@ class Theme(object):
             self.port_midi_alsa_bg_sel = QColor(64 + 50, 112 + 50, 18 + 50)
             self.port_parameter_bg = QColor(101, 47, 16)
             self.port_parameter_bg_sel = QColor(101 + 50, 47 + 50, 16 + 50)
+            
+            self.pair_audio_jack_pen = QPen(QColor(103, 130, 166), 2)
+            self.pair_audio_jack_pen_sel = QPen(QColor(103 + 136, 190 + 130, 226 + 130), 1)
+            self.pair_audio_jack_bg = QColor(0, 0, 120)
+            self.pair_audio_jack_bg_sel = QColor(0 + 150, 0 + 150, 120 + 150)
 
             self.port_audio_jack_text = self.port_text
             self.port_audio_jack_text_sel = self.port_text
@@ -281,7 +298,8 @@ class Theme(object):
             self.port_midi_alsa_text_sel = self.port_text
             self.port_parameter_text = self.port_text
             self.port_parameter_text_sel = self.port_text
-
+            
+            self.port_in_pair_width = 18
             self.port_height   = 16
             self.port_offset   = 0
             self.port_spacing  = 2
@@ -354,6 +372,11 @@ class Theme(object):
             self.port_midi_alsa_bg_sel = QColor(255, 0, 0)
             self.port_parameter_bg = QColor(101, 47, 17)
             self.port_parameter_bg_sel = QColor(255, 0, 0)
+            
+            self.pair_audio_jack_pen = QPen(QColor(35, 61, 99), 0)
+            self.pair_audio_jack_pen_sel = QPen(QColor(255, 0, 0), 0)
+            self.pair_audio_jack_bg = QColor(27, 47, 75)
+            self.pair_audio_jack_bg_sel = QColor(255, 0, 0)
 
             self.port_audio_jack_text = self.port_text
             self.port_audio_jack_text_sel = self.port_text
@@ -363,7 +386,8 @@ class Theme(object):
             self.port_midi_alsa_text_sel = self.port_text
             self.port_parameter_text = self.port_text
             self.port_parameter_text_sel = self.port_text
-
+            
+            self.port_in_pair_width = 18
             self.port_height   = 14
             self.port_offset   = -1
             self.port_spacing  = 1
@@ -439,7 +463,12 @@ class Theme(object):
             self.port_midi_alsa_bg_sel = selPortBG
             self.port_parameter_bg = normalPortBG
             self.port_parameter_bg_sel = selPortBG
-
+            
+            self.pair_audio_jack_pen = QPen(selPortBG, 2)
+            self.pair_audio_jack_pen_sel = QPen(QColor(1, 230, 238), 1)
+            self.pair_audio_jack_bg = normalPortBG
+            self.pair_audio_jack_bg_sel = selPortBG
+            
             self.port_audio_jack_text = self.port_text
             self.port_audio_jack_text_sel = self.port_audio_jack_pen_sel
             self.port_midi_jack_text = self.port_text
@@ -450,6 +479,7 @@ class Theme(object):
             self.port_parameter_text_sel = self.port_parameter_pen_sel
 
             # missing, ports 2
+            self.port_in_pair_width = 18
             self.port_height   = 21
             self.port_offset   = 1
             self.port_spacing  = 3


### PR DESCRIPTION
That's here.
Sorry I just made a PR to your 'develop' branch. I'll remove it.

So, I didn't remember it represents so much code.
Sorry the code is quite dirty now, but that gives you an idea of how it works.

I named this "pair" to not be confused with groups, but it's not conceptually limited to stereo (even if there is no user way to make more than 2 ports pair).

Here stereo detection is set on (detected with port names), it can be set of commenting all the condition( if 0 == 0: line 1312).
There is also the possibility to set a port as stereo with a neighbor via contextMenu on port.
Possibility to split the pair via context menu on pair widget.

Pairs are saved in settings. Here there is something to decide,
I think it should be: save in settings + save in project (with priority to project, and no save in settings in carla patchbay).

Little thing more : Linemov becomes dotted hover a connected port (means it would disconnect).