### PR TITLE
fix crash in carla_get_paramter_info()

### DIFF
--- a/source/backend/CarlaStandalone.cpp
+++ b/source/backend/CarlaStandalone.cpp
@@ -1330,31 +1330,31 @@ const CarlaParameterInfo* carla_get_parameter_info(CarlaHostHandle handle, uint 
     retInfo.scalePointCount = 0;
 
     // cleanup
-    if (retInfo.name != gNullCharPtr)
+    if (strcmp (retInfo.name, gNullCharPtr))
     {
         delete[] retInfo.name;
         retInfo.name = gNullCharPtr;
     }
 
-    if (retInfo.symbol != gNullCharPtr)
+    if (strcmp (retInfo.symbol, gNullCharPtr))
     {
         delete[] retInfo.symbol;
         retInfo.symbol = gNullCharPtr;
     }
 
-    if (retInfo.unit != gNullCharPtr)
+    if (strcmp (retInfo.unit, gNullCharPtr))
     {
         delete[] retInfo.unit;
         retInfo.unit = gNullCharPtr;
     }
 
-    if (retInfo.comment != gNullCharPtr)
+    if (strcmp (retInfo.comment, gNullCharPtr))
     {
         delete[] retInfo.comment;
         retInfo.comment = gNullCharPtr;
     }
 
-    if (retInfo.groupName != gNullCharPtr)
+    if (strcmp (retInfo.groupName, gNullCharPtr))
     {
         delete[] retInfo.groupName;
         retInfo.groupName = gNullCharPtr;


### PR DESCRIPTION
the address of retInfo.name is not the same as the address of gNullCharPtr

```
free(): invalid pointer

Thread 1 "zrythm" received signal SIGABRT, Aborted.
0x00007ffff5e427fa in raise () from /gnu/store/ahqgl4h89xqj695lgqvsaf6zh2nhy4pj-glibc-2.29/lib/libc.so.6
(gdb) bt
#0  0x00007ffff5e427fa in raise () from /gnu/store/ahqgl4h89xqj695lgqvsaf6zh2nhy4pj-glibc-2.29/lib/libc.so.6
#1  0x00007ffff5e43891 in abort () from /gnu/store/ahqgl4h89xqj695lgqvsaf6zh2nhy4pj-glibc-2.29/lib/libc.so.6
#2  0x00007ffff5e83757 in __libc_message () from /gnu/store/ahqgl4h89xqj695lgqvsaf6zh2nhy4pj-glibc-2.29/lib/libc.so.6
#3  0x00007ffff5e89e8a in malloc_printerr () from /gnu/store/ahqgl4h89xqj695lgqvsaf6zh2nhy4pj-glibc-2.29/lib/libc.so.6
#4  0x00007ffff5e8b56c in _int_free () from /gnu/store/ahqgl4h89xqj695lgqvsaf6zh2nhy4pj-glibc-2.29/lib/libc.so.6
#5  0x00007ffff67470fe in carla_get_parameter_info (handle=0x1b98cf0, pluginId=0, parameterId=0) at CarlaStandalone.cpp:1335
#6  0x000000000049deb3 in create_ports (self=0x36cf9f0) at ../src/plugins/carla_native_plugin.c:901
#7  0x000000000049df82 in carla_native_plugin_instantiate (self=0x36cf9f0) at ../src/plugins/carla_native_plugin.c:929
#8  0x000000000047cd99 in plugin_instantiate (pl=0x13fea20) at ../src/plugins/plugin.c:637
#9  0x000000000044155b in create (self=0x3390860, idx=0, add_to_project=0) at ../src/actions/create_tracks_action.c:110
#10 0x0000000000441ad8 in create_tracks_action_new (type=TRACK_TYPE_AUDIO_BUS, pl_descr=0x7fffe8a45110, file=0x0, pos=3, num_tracks=1) at ../src/actions/create_tracks_action.c:255
#11 0x000000000050f3ae in on_row_activated (tree_view=0x1317b80, tp=0x3368a30, column=0x1bc3b70, user_data=0x1ba9350) at ../src/gui/widgets/plugin_browser.c:86
#12 0x00007ffff7c6819c in _gtk_marshal_VOID__BOXED_OBJECTv () from /home/alex/.guix-profile/lib/libgtk-3.so.0
#13 0x00007ffff73f6d86 in _g_closure_invoke_va () from /home/alex/.guix-profile/lib/libgobject-2.0.so.0
#14 0x00007ffff7412856 in g_signal_emit_valist () from /home/alex/.guix-profile/lib/libgobject-2.0.so.0
#15 0x00007ffff7412f32 in g_signal_emit () from /home/alex/.guix-profile/lib/libgobject-2.0.so.0
#16 0x00007ffff7c02eda in gtk_tree_view_multipress_gesture_pressed () from /home/alex/.guix-profile/lib/libgtk-3.so.0
#17 0x00007ffff7c6958d in _gtk_marshal_VOID__INT_DOUBLE_DOUBLEv () from /home/alex/.guix-profile/lib/libgtk-3.so.0
#18 0x00007ffff73f6d86 in _g_closure_invoke_va () from /home/alex/.guix-profile/lib/libgobject-2.0.so.0
#19 0x00007ffff7412856 in g_signal_emit_valist () from /home/alex/.guix-profile/lib/libgobject-2.0.so.0
#20 0x00007ffff7412f32 in g_signal_emit () from /home/alex/.guix-profile/lib/libgobject-2.0.so.0
#21 0x00007ffff7a9880c in gtk_gesture_multi_press_begin () from /home/alex/.guix-profile/lib/libgtk-3.so.0
#22 0x00007ffff73f9885 in g_cclosure_marshal_VOID__BOXEDv () from /home/alex/.guix-profile/lib/libgobject-2.0.so.0
#23 0x00007ffff73f6d86 in _g_closure_invoke_va () from /home/alex/.guix-profile/lib/libgobject-2.0.so.0
#24 0x00007ffff7412856 in g_signal_emit_valist () from /home/alex/.guix-profile/lib/libgobject-2.0.so.0
#25 0x00007ffff7412f32 in g_signal_emit () from /home/alex/.guix-profile/lib/libgobject-2.0.so.0
#26 0x00007ffff7a958ee in _gtk_gesture_check_recognized () from /home/alex/.guix-profile/lib/libgtk-3.so.0
#27 0x00007ffff7a96d4b in gtk_gesture_handle_event () from /home/alex/.guix-profile/lib/libgtk-3.so.0
#28 0x00007ffff7a999be in gtk_gesture_single_handle_event () from /home/alex/.guix-profile/lib/libgtk-3.so.0
#29 0x00007ffff7a63f21 in gtk_event_controller_handle_event () from /home/alex/.guix-profile/lib/libgtk-3.so.0
#30 0x00007ffff7c109cb in _gtk_widget_run_controllers () from /home/alex/.guix-profile/lib/libgtk-3.so.0
#31 0x00007ffff7c63b0b in _gtk_marshal_BOOLEAN__BOXED () from /home/alex/.guix-profile/lib/libgtk-3.so.0
#32 0x00007ffff73f6b4d in g_closure_invoke () from /home/alex/.guix-profile/lib/libgobject-2.0.so.0
#33 0x00007ffff7409a98 in signal_emit_unlocked_R () from /home/alex/.guix-profile/lib/libgobject-2.0.so.0
#34 0x00007ffff7411f2c in g_signal_emit_valist () from /home/alex/.guix-profile/lib/libgobject-2.0.so.0
#35 0x00007ffff7412f32 in g_signal_emit () from /home/alex/.guix-profile/lib/libgobject-2.0.so.0
#36 0x00007ffff7c12b34 in gtk_widget_event_internal () from /home/alex/.guix-profile/lib/libgtk-3.so.0
#37 0x00007ffff7adce3e in propagate_event () from /home/alex/.guix-profile/lib/libgtk-3.so.0
#38 0x00007ffff7adee68 in gtk_main_do_event () from /home/alex/.guix-profile/lib/libgtk-3.so.0
#39 0x00007ffff77e02d5 in _gdk_event_emit () from /home/alex/.guix-profile/lib/libgdk-3.so.0
#40 0x00007ffff78109d2 in gdk_event_source_dispatch () from /home/alex/.guix-profile/lib/libgdk-3.so.0
#41 0x00007ffff7311787 in g_main_context_dispatch () from /home/alex/.guix-profile/lib/libglib-2.0.so.0
#42 0x00007ffff7311998 in g_main_context_iterate.isra () from /home/alex/.guix-profile/lib/libglib-2.0.so.0
#43 0x00007ffff7311a1c in g_main_context_iteration () from /home/alex/.guix-profile/lib/libglib-2.0.so.0
#44 0x00007ffff7513e2d in g_application_run () from /home/alex/.guix-profile/lib/libgio-2.0.so.0
#45 0x0000000000436a2d in main (argc=1, argv=0x7fffffffd008) at ../src/main.c:424
(gdb) up
#1  0x00007ffff5e43891 in abort () from /gnu/store/ahqgl4h89xqj695lgqvsaf6zh2nhy4pj-glibc-2.29/lib/libc.so.6
(gdb) 
#2  0x00007ffff5e83757 in __libc_message () from /gnu/store/ahqgl4h89xqj695lgqvsaf6zh2nhy4pj-glibc-2.29/lib/libc.so.6
(gdb) 
#3  0x00007ffff5e89e8a in malloc_printerr () from /gnu/store/ahqgl4h89xqj695lgqvsaf6zh2nhy4pj-glibc-2.29/lib/libc.so.6
(gdb) 
#4  0x00007ffff5e8b56c in _int_free () from /gnu/store/ahqgl4h89xqj695lgqvsaf6zh2nhy4pj-glibc-2.29/lib/libc.so.6
(gdb) 
#5  0x00007ffff67470fe in carla_get_parameter_info (handle=0x1b98cf0, pluginId=0, parameterId=0) at CarlaStandalone.cpp:1335
1335	CarlaStandalone.cpp: No such file or directory.
(gdb) p retInfo 
$1 = {name = 0x7ffff6eed275 "", symbol = 0x7ffff6eed275 "", unit = 0x7ffff6eed275 "", comment = 0x7ffff6eed275 "", groupName = 0x7ffff6eed275 "", scalePointCount = 0}
(gdb) p gNullCharPtr 
$2 = 0x7ffff693714c ""
```