### PR TITLE
Fix MinGW JUCE DEBUG builds

### DIFF
--- a/source/modules/juce_audio_processors/Makefile
+++ b/source/modules/juce_audio_processors/Makefile
@@ -18,7 +18,7 @@ else
 # needed by vst3
 BUILD_CXX_FLAGS += -w
 ifeq ($(DEBUG),true)
-BUILD_CXX_FLAGS += -DDEVELOPMENT -D_DEBUG
+BUILD_CXX_FLAGS += -DDEVELOPMENT -D_DEBUG -Wa,-mbig-obj
 else
 BUILD_CXX_FLAGS += -DRELEASE
 endif

--- a/source/modules/juce_gui_basics/Makefile
+++ b/source/modules/juce_gui_basics/Makefile
@@ -12,6 +12,12 @@ include ../Makefile.mk
 
 BUILD_CXX_FLAGS += $(JUCE_GUI_BASICS_FLAGS) -I..
 
+ifeq ($(DEBUG),true)
+BUILD_CXX_FLAGS += -DDEVELOPMENT -D_DEBUG -Wa,-mbig-obj
+else
+BUILD_CXX_FLAGS += -DRELEASE
+endif
+
 ifeq ($(WIN32),true)
 BUILD_CXX_FLAGS += -Wno-missing-field-initializers -Wno-strict-aliasing -Wno-strict-overflow
 endif


### PR DESCRIPTION
Compilation was failing with:

```
/usr/lib/gcc/x86_64-w64-mingw32/9.3.0/../../../../x86_64-w64-mingw32/bin/as: ../../../build/juce_gui_basics/Debug/juce_gui_basics.cpp.win64.o: too many sections
{standard input}: Fatal error: can't close ../../../build/juce_gui_basics/Debug/juce_gui_basics.cpp.win64.o: file too big
```

Solution is to allow bigger object files with the `-mbig-obj` GNU assembler
flag

Source: https://digitalkarabela.com/mingw-w64-how-to-fix-file-too-big-too-many-sections/