### PR TITLE
Fix JUCE compilation on Linux with DEBUG=true

### DIFF
--- a/source/modules/juce_audio_processors/Makefile
+++ b/source/modules/juce_audio_processors/Makefile
@@ -12,10 +12,6 @@ include ../Makefile.mk
 
 BUILD_CXX_FLAGS += $(JUCE_AUDIO_PROCESSORS_FLAGS) -I$(CWD)/includes/vst3sdk -I..
 
-# needed for bloated juce
-ifeq ($(DEBUG),true)
-BUILD_CXX_FLAGS += -Wa,-mbig-obj
-endif
 
 # needed by vst3
 ifeq ($(DEBUG),true)
@@ -27,6 +23,10 @@ endif
 # needed by vst3 on mingw
 ifeq ($(WIN32),true)
 BUILD_CXX_FLAGS += -D_NATIVE_WCHAR_T_DEFINED -D__wchar_t=wchar_t -fpermissive -Wno-unknown-pragmas
+# needed for bloated juce
+ifeq ($(DEBUG),true)
+BUILD_CXX_FLAGS += -Wa,-mbig-obj
+endif
 endif
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/source/modules/juce_gui_basics/Makefile
+++ b/source/modules/juce_gui_basics/Makefile
@@ -12,14 +12,13 @@ include ../Makefile.mk
 
 BUILD_CXX_FLAGS += $(JUCE_GUI_BASICS_FLAGS) -I..
 
+# needed for mingw juce
+ifeq ($(WIN32),true)
+BUILD_CXX_FLAGS += -Wno-missing-field-initializers -Wno-multichar
 # needed for bloated juce
 ifeq ($(DEBUG),true)
 BUILD_CXX_FLAGS += -Wa,-mbig-obj
 endif
-
-# needed for mingw juce
-ifeq ($(WIN32),true)
-BUILD_CXX_FLAGS += -Wno-missing-field-initializers -Wno-multichar
 endif
 
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
GCC does not recognize the `-mbig-obj` MinGW flag, it should only be
added if DEBUG is true AND we are crosscompiling.