### PR TITLE
VST2: Fix creation of a rack when one of the parameters is a NaN

### DIFF
--- a/source/frontend/widgets/pixmapdial.py
+++ b/source/frontend/widgets/pixmapdial.py
@@ -19,7 +19,7 @@
 # ------------------------------------------------------------------------------------------------------------
 # Imports (Global)
 
-from math import cos, floor, pi, sin
+from math import cos, floor, pi, sin, isnan
 
 from PyQt5.QtCore import pyqtSignal, pyqtSlot, Qt, QEvent, QPointF, QRectF, QTimer, QSize
 from PyQt5.QtGui import QColor, QConicalGradient, QFont, QFontMetrics
@@ -241,7 +241,7 @@ class PixmapDial(QDial):
         self.fMaximum = value
 
     def setValue(self, value, emitSignal=False):
-        if self.fRealValue == value:
+        if self.fRealValue == value or isnan(value):
             return
 
         if value <= self.fMinimum:


### PR DESCRIPTION
On some quirky Windows VST2 (old SWAM instruments) or old Linux ones (InsertPizHere plugins), a NaN parameter value would be sent.
This throws an error in the frontend code and prevent carla from creating the corresponding rack.
We workaround that by just returning early from PixmapDialsetValue() if the value is a NaN

Fixes #1143 