### PR TITLE
CarlaNative.h: move extern "C" after the includes to fix clang/libc++

### DIFF
--- a/source/includes/CarlaNative.h
+++ b/source/includes/CarlaNative.h
@@ -18,13 +18,13 @@
 #ifndef CARLA_NATIVE_H_INCLUDED
 #define CARLA_NATIVE_H_INCLUDED
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "CarlaDefines.h"
 #include <stddef.h>
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /*!
  * @defgroup CarlaNativeAPI Carla Native API


### PR DESCRIPTION
With clang12, this ordering causes a big bunch of errors like:

```
In file included from midi-pattern.cpp:18:
In file included from ../includes/CarlaNativeExtUI.hpp:21:
In file included from ../includes/CarlaNative.hpp:21:
In file included from ../includes/CarlaNative.h:25:
In file included from ../includes/CarlaDefines.h:91:
/usr/include/c++/v1/cstddef:56:1: error: templates must have C++ linkage
template <class _Tp> struct __libcpp_is_integral                     { enum { value = 0 }; };
^~~~~~~~~~~~~~~~~~~~
../includes/CarlaNative.h:22:1: note: extern "C" language linkage specification begins here
extern "C" {
^
```