### PR TITLE
Fix Windows cross compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,21 +15,18 @@ jobs:
     # linux with macOS cross-compilation
     - os: linux
       compiler: gcc
-      dist: trusty
       env:
         - TARGET="macos"
 
     # linux with win32 cross-compilation
     - os: linux
       compiler: gcc
-      dist: trusty
       env:
         - TARGET="win32"
 
     # linux with win64 cross-compilation
     - os: linux
       compiler: gcc
-      dist: trusty
       env:
         - TARGET="win64"
 

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+
 sudo add-apt-repository -y ppa:kxstudio-debian/kxstudio
 sudo add-apt-repository -y ppa:kxstudio-debian/mingw
 sudo add-apt-repository -y ppa:kxstudio-debian/toolchain

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -93,15 +93,11 @@ elif [ "${TARGET}" = "macos" ]; then
 
 elif [ "${TARGET}" = "win32" ]; then
     sudo apt-get install -y \
-        mingw32-x-gcc \
-        mingw32-x-pkgconfig
+        mingw-w64
 
 elif [ "${TARGET}" = "win64" ]; then
     sudo apt-get install -y \
-        mingw32-x-gcc \
-        mingw32-x-pkgconfig \
-        mingw64-x-gcc \
-        mingw64-x-pkgconfig
+        mingw-w64
 
 elif [ "${TARGET}" = "pylint" ]; then
     sudo apt-get install -y \

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -88,8 +88,9 @@ elif [ "${TARGET}" = "linux-juce-strict" ]; then
 
 elif [ "${TARGET}" = "macos" ]; then
     sudo apt-get install -y \
-        pkg-config \
-        apple-x86-setup
+        pkg-config 
+        # Cant find this package
+        #apple-x86-setup
 
 elif [ "${TARGET}" = "win32" ]; then
     sudo apt-get install -y \


### PR DESCRIPTION
Fix win32 and win64 builds by:
- adding a missing pub key
- update trusty to bionic (some missing packages in trusty)
- migrate from mingw32/mingw64 packages to mingw-w64