### PR TITLE
compile python files to reduce program startup time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ MODULEDIR := $(CURDIR)/build/modules/Release
 endif
 
 VERSION   := 2.3.0
-
+PYTHON    := python3
 # ---------------------------------------------------------------------------------------------------------------------
 
 all: backend discovery bridges-plugin bridges-ui frontend interposer libjack plugin theme
@@ -608,6 +608,8 @@ endif
 		bin/resources/carla-plugin-patchbay \
 		bin/resources/*-ui \
 		$(DESTDIR)$(DATADIR)/carla/resources
+		
+	
 endif # CPPMODE
 
 ifeq ($(HAVE_THEME),true)
@@ -767,6 +769,10 @@ ifeq ($(CAN_GENERATE_LV2_TTL),true)
 endif
 endif
 
+	# -------------------------------------------------------------------------------------------------------------
+	# compile all python .pyc files to __pycache__ for faster application start
+	$(PYTHON) -m compileall $(DATADIR)/carla
+	
 # ---------------------------------------------------------------------------------------------------------------------
 
 ifneq ($(EXTERNAL_PLUGINS),true)


### PR DESCRIPTION
Hi.
The idea is to compile .pyc files in __pycache__ at make install.

This reduce the startup duration of carla. When a python file is imported, python compiles this file in __pycache__/file.pyc . If this file already exists and matches perfecty with the python file version, then, python uses the compiled file. If we don't install theses compiled files, compilation is done at each startup because the dir is read only.

for comparaison, see the return without __pycache__ of `time carla --version`

```
time carla --version
Using Carla version 2.3.0
  Python version: 3.7.3
  Qt version:     5.11.3
  PyQt version:   5.11.3
  Binary dir:     /usr/local/lib/carla
  Resources dir:  /usr/local/share/carla/resources

real    0m0,707s
user    0m0,605s
sys     0m0,082s
```

and with __pycache__:
```
Using Carla version 2.3.0
  Python version: 3.7.3
  Qt version:     5.11.3
  PyQt version:   5.11.3
  Binary dir:     /usr/local/lib/carla
  Resources dir:  /usr/local/share/carla/resources

real    0m0,426s
user    0m0,360s
sys     0m0,049s
```

Note that the compilation is done at install, and not at make, else when files are moved, compiled files are not considered as matching with python files. It means that python checks if it matches with absolute paths.