### PR TITLE
Add missing separator in SF2 search path

### DIFF
--- a/source/frontend/carla_shared.py
+++ b/source/frontend/carla_shared.py
@@ -468,7 +468,7 @@ else:
     DEFAULT_VST3_PATH   += ":/usr/local/lib/vst3"
 
     DEFAULT_SF2_PATH     = HOME + "/.sounds/sf2"
-    DEFAULT_SF2_PATH    += HOME + "/.sounds/sf3"
+    DEFAULT_SF2_PATH    += HOME + ":/.sounds/sf3"
     DEFAULT_SF2_PATH    += ":/usr/share/sounds/sf2"
     DEFAULT_SF2_PATH    += ":/usr/share/sounds/sf3"
     DEFAULT_SF2_PATH    += ":/usr/share/soundfonts"


### PR DESCRIPTION
The SF2 search path is missing a separator which results in a config file entry like 

`SF2=/home/faith/.sounds/sf2/home/faith/.sounds/sf3, /usr/share/soundfonts, /usr/share/sounds/sf2, /usr/share/sounds/sf3
`
by default. Note the missing comma between the first "sf2" and the following "/home"

This pull simply adds the missing ":" in the source.