### PR TITLE
Set flag `windowAppearsOnTaskbar` on plugin window

### DIFF
--- a/source/utils/JucePluginWindow.hpp
+++ b/source/utils/JucePluginWindow.hpp
@@ -106,7 +106,7 @@ protected:
 
     int getDesktopWindowStyleFlags() const override
     {
-        return ComponentPeer::windowHasDropShadow | ComponentPeer::windowHasTitleBar | ComponentPeer::windowHasCloseButton;
+        return ComponentPeer::windowAppearsOnTaskbar | ComponentPeer::windowHasDropShadow | ComponentPeer::windowHasTitleBar | ComponentPeer::windowHasCloseButton;
     }
 
 #ifndef CARLA_OS_LINUX


### PR DESCRIPTION
There was a curious regression introduced in a79c192, which makes the plugin window behave badly, when it's run under `carla-single`.
It would not appear in the window list, and it would cause the window ordering and focus to act erratically. (at least in XFCE desktop)