### PR TITLE
Add disconnect-all-of-group menu item to patchbay

### DIFF
--- a/source/frontend/patchcanvas/canvasbox.py
+++ b/source/frontend/patchcanvas/canvasbox.py
@@ -502,10 +502,31 @@ class CanvasBox(QGraphicsObject):
                     conn_list_ids.append(tmp_conn_id)
 
         if len(conn_list) > 0:
+            groups = {}
             for conn_id, group_id, port_id in conn_list:
+                groups.setdefault(group_id, []).append(conn_id)
                 act_x_disc = discMenu.addAction(CanvasGetFullPortName(group_id, port_id))
                 act_x_disc.setData(conn_id)
                 act_x_disc.triggered.connect(canvas.qobject.PortContextMenuDisconnect)
+
+            # menu entries for disconnecting multiple connections to the same group
+            separator_added = False
+            for group_id, conn_ids in groups.items():
+                if len(conn_ids) < 2:
+                    continue
+                for group in canvas.group_list:
+                    if group.group_id == group_id:
+                        group_name = group.group_name
+                        break
+                else:
+                    qCritical("Couldn't find group for group id {}".format(group_id))
+                    continue
+                if not separator_added:
+                    discMenu.addSeparator()
+                    separator_added = True
+                act_x_disc_multi = discMenu.addAction("{} (all {} ports)".format(group_name, len(conn_ids)))
+                act_x_disc_multi.setData(conn_ids)
+                act_x_disc_multi.triggered.connect(canvas.qobject.PortContextMenuDisconnect)
         else:
             act_x_disc = discMenu.addAction("No connections")
             act_x_disc.setEnabled(False)

--- a/source/frontend/patchcanvas/patchcanvas.py
+++ b/source/frontend/patchcanvas/patchcanvas.py
@@ -138,11 +138,16 @@ class CanvasObject(QObject):
     @pyqtSlot()
     def PortContextMenuDisconnect(self):
         try:
-            connectionId = int(self.sender().data())
+            connection_ids = self.sender().data()
+            if isinstance(connection_ids, (list, tuple)):
+                connection_ids = [int(conn_id) for conn_id in connection_ids]
+            else:
+                connection_ids = [int(connection_ids)]
         except:
             return
 
-        CanvasCallback(ACTION_PORTS_DISCONNECT, connectionId, 0, "")
+        for connection_id in connection_ids:
+            CanvasCallback(ACTION_PORTS_DISCONNECT, connection_id, 0, "")
 
     @pyqtSlot(int, bool, int, int)
     def boxPositionChanged(self, groupId, split, x, y):


### PR DESCRIPTION
If one group has multiple connections to another group an extra menu
item is added to its disconnect context menu, which allows the user to
disconnect it all at once. The entry is added at the bottom of the
disconnect menu in the form of "Groupname (all x ports)". This comes in
very handy when the user wants to disconnect a soundcard from their
current application.

PortContextMenuDisconnect() now also accepts a list via
setData()/data(), so we can disconnect multiple ports at once.

---

Heyhey, first PR on this project, hope this feature is interesting to you!
I'm a bit unsure about how the patchcanvas module is maintained. I know it is at least used in Catia. Would we need to port this change over? Especially as I augment the functionality of `PortContextMenuDisconnect()`.