### PR TITLE
jsfx: identification by relative path

### DIFF
--- a/source/backend/plugin/CarlaPluginJSFX.cpp
+++ b/source/backend/plugin/CarlaPluginJSFX.cpp
@@ -858,11 +858,13 @@ public:
             if (const char* paths = pData->engine->getOptions().pathJSFX)
                 splitPaths = StringArray::fromTokens(CharPointer_UTF8(paths), CARLA_OS_SPLIT_STR, "");
 
+            File file;
             if (filename && filename[0] != '\0')
+                file = File(CharPointer_UTF8(filename));
+
+            if (file.isNotNull() && file.existsAsFile())
             {
                 // find which engine search path we're in, and use this as the root
-                const File file = File(CharPointer_UTF8(filename));
-
                 for (int i = 0; i < splitPaths.size() && !unit; ++i)
                 {
                     const File currentPath(splitPaths[i]);

--- a/source/backend/plugin/CarlaPluginJSFX.cpp
+++ b/source/backend/plugin/CarlaPluginJSFX.cpp
@@ -931,8 +931,7 @@ public:
         }
         else
         {
-            String baseName = File(fFilename).getFileNameWithoutExtension();
-            pData->name = pData->engine->getUniquePluginName(baseName.toRawUTF8());
+            pData->name = carla_strdup(fEffect->desc);
         }
 
         pData->filename = carla_strdup(fFilename.c_str());

--- a/source/backend/utils/CachedPlugins.cpp
+++ b/source/backend/utils/CachedPlugins.cpp
@@ -673,7 +673,6 @@ static const CarlaCachedPluginInfo* get_cached_plugin_jsfx(const CarlaJsfxUnit& 
     static CarlaString name, label;
 
     const water::File unitFilePath = unit.getFilePath();
-    name = unitFilePath.getFileNameWithoutExtension().toRawUTF8();
     label = unit.getFileId().toRawUTF8();
 
     {
@@ -691,6 +690,8 @@ static const CarlaCachedPluginInfo* get_cached_plugin_jsfx(const CarlaJsfxUnit& 
     }
 
     info.valid         = true;
+
+    name = effect.desc;
 
     // NOTE: count can be -1 in case of "none"
     info.audioIns = (effect.numInputs == -1) ? 0 : (uint32_t)effect.numInputs;

--- a/source/discovery/carla-discovery.cpp
+++ b/source/discovery/carla-discovery.cpp
@@ -1664,10 +1664,11 @@ static void do_jsfx_check(const char* const filename, bool doInit)
 {
     JsusFx::init();
 
-    // TODO(jsfx) determinine the import search path correctly
+    const water::File file = File(CharPointer_UTF8(filename));
+    const water::File rootPath(file.getParentDirectory());
 
-    water::File file(filename);
-    CarlaJsusFxPathLibrary pathLibrary(file);
+    const CarlaJsfxUnit unit(rootPath, file);
+    CarlaJsusFxPathLibrary pathLibrary(unit);
 
     CarlaJsusFx effect(pathLibrary);
     effect.setQuiet(true);
@@ -1683,29 +1684,9 @@ static void do_jsfx_check(const char* const filename, bool doInit)
     effect.gfx = &gfxAPI;
     gfxAPI.init(effect.m_vm);
 
-    ///
-    if (doInit)
-    {
-        int compileFlags =
-            JsusFx::kCompileFlag_CompileSerializeSection |
-            JsusFx::kCompileFlag_CompileGraphicsSection;
+    // do not attempt to compile it, because the import path is not known
+    (void)doInit;
 
-        {
-            const CarlaScopedLocale csl;
-            if (!effect.compile(pathLibrary, filename, compileFlags))
-            {
-                DISCOVERY_OUT("error", "Cannot compile the JSFX plugin");
-                return;
-            }
-        }
-
-#if 0 // TODO(jsfx) when supporting custom graphics
-        if (effect.hasGraphicsSection())
-            hints |= PLUGIN_HAS_CUSTOM_UI;
-        // TODO(jsfx) there should be a way to check this without compiling
-#endif
-    }
-    else
     {
         const CarlaScopedLocale csl;
         if (!effect.readHeader(pathLibrary, filename))

--- a/source/discovery/carla-discovery.cpp
+++ b/source/discovery/carla-discovery.cpp
@@ -1704,8 +1704,6 @@ static void do_jsfx_check(const char* const filename, bool doInit)
         return;
     }
 
-    water::String baseName = water::File(filename).getFileNameWithoutExtension();
-
     // NOTE: count can be -1 in case of "none"
     uint32_t audioIns = (effect.numInputs == -1) ? 0 : (uint32_t)effect.numInputs;
     uint32_t audioOuts = (effect.numOutputs == -1) ? 0 : (uint32_t)effect.numOutputs;
@@ -1723,7 +1721,7 @@ static void do_jsfx_check(const char* const filename, bool doInit)
     DISCOVERY_OUT("init", "-----------");
     DISCOVERY_OUT("build", BINARY_NATIVE);
     DISCOVERY_OUT("hints", hints);
-    DISCOVERY_OUT("name", baseName.toRawUTF8());
+    DISCOVERY_OUT("name", effect.desc);
     DISCOVERY_OUT("label", filename);
     DISCOVERY_OUT("audio.ins", audioIns);
     DISCOVERY_OUT("audio.outs", audioOuts);

--- a/source/frontend/carla_database.py
+++ b/source/frontend/carla_database.py
@@ -358,11 +358,6 @@ def checkPluginCached(desc, ptype):
         pinfo['filename'] = pinfo['label']
         pinfo['label']    = pinfo['name']
 
-    # TODO(jsfx) what to do here?
-    elif ptype == PLUGIN_JSFX:
-        pinfo['filename'] = pinfo['label']
-        pinfo['label']    = pinfo['name']
-
     return pinfo
 
 def checkPluginLADSPA(filename, tool, wineSettings=None):

--- a/source/utils/CarlaJsfxUtils.hpp
+++ b/source/utils/CarlaJsfxUtils.hpp
@@ -86,18 +86,52 @@ private:
 
 // -------------------------------------------------------------------------------------------------------------------
 
-class CarlaJsusFxPathLibrary : public JsusFxPathLibrary_Basic
+class CarlaJsfxUnit
 {
 public:
-    explicit CarlaJsusFxPathLibrary(const water::File &file)
-        : JsusFxPathLibrary_Basic(determineDataRoot(file).c_str())
+    CarlaJsfxUnit() = default;
+
+    CarlaJsfxUnit(const water::File& rootPath, const water::File& filePath)
+        : fRootPath(rootPath), fFileId(filePath.getRelativePathFrom(rootPath))
     {
+#ifdef _WIN32
+        fFileId.replaceCharacter('\\', '/');
+#endif
+    }
+
+    explicit operator bool() const
+    {
+        return fFileId.isNotEmpty();
+    }
+
+    const water::File& getRootPath() const
+    {
+        return fRootPath;
+    }
+
+    const water::String& getFileId() const
+    {
+        return fFileId;
+    }
+
+    water::File getFilePath() const
+    {
+        return fRootPath.getChildFile(fFileId);
     }
 
 private:
-    static std::string determineDataRoot(const water::File &file)
+    water::File fRootPath;
+    water::String fFileId;
+};
+
+// -------------------------------------------------------------------------------------------------------------------
+
+class CarlaJsusFxPathLibrary : public JsusFxPathLibrary_Basic
+{
+public:
+    explicit CarlaJsusFxPathLibrary(const CarlaJsfxUnit &unit)
+        : JsusFxPathLibrary_Basic(unit.getRootPath().getFullPathName().toRawUTF8())
     {
-        return file.getParentDirectory().getFullPathName().toRawUTF8();
     }
 };
 

--- a/source/utils/CarlaJsfxUtils.hpp
+++ b/source/utils/CarlaJsfxUtils.hpp
@@ -18,6 +18,7 @@
 #ifndef CARLA_JSFX_UTILS_HPP_INCLUDED
 #define CARLA_JSFX_UTILS_HPP_INCLUDED
 
+#include "CarlaDefines.h"
 #include "CarlaUtils.hpp"
 #include "CarlaString.hpp"
 #include "CarlaBase64Utils.hpp"
@@ -94,7 +95,7 @@ public:
     CarlaJsfxUnit(const water::File& rootPath, const water::File& filePath)
         : fRootPath(rootPath), fFileId(filePath.getRelativePathFrom(rootPath))
     {
-#ifdef _WIN32
+#ifdef CARLA_OS_WIN
         fFileId.replaceCharacter('\\', '/');
 #endif
     }

--- a/source/utils/CarlaStateUtils.cpp
+++ b/source/utils/CarlaStateUtils.cpp
@@ -562,9 +562,6 @@ void CarlaStateSave::dumpToMemoryStream(MemoryOutputStream& content) const
             infoXml << "   <Identifier>" << xmlSafeString(label, true) << "</Identifier>\n";
             break;
         case PLUGIN_JSFX:
-            // TODO(jsfx) this might be incorrect
-            infoXml << "   <Filename>"   << xmlSafeString(binary, true) << "</Filename>\n";
-            break;
         case PLUGIN_DLS:
         case PLUGIN_GIG:
         case PLUGIN_SF2:


### PR DESCRIPTION
#1487

This work would allow JSFX to be identified by their relative file ID.
This relative file ID is kept in the `label` field.

The JSFX unit will be identified by the pair of these two strings: root path, file ID
Their concatenation produces the full path.
A file ID is normalized to forward-slash separators.

The CarlaJsfxPlugin is edited such that it can load by either `filename` or `label`.

~~Draft because it's not tried yet.~~