### PR TITLE
Disable GraphicsScene indexing method to prevent crashes

### DIFF
--- a/source/frontend/patchcanvas/scene.py
+++ b/source/frontend/patchcanvas/scene.py
@@ -81,6 +81,7 @@ class PatchScene(QGraphicsScene):
         self.m_cursor_cut = None
         self.m_cursor_zoom = None
 
+        self.setItemIndexMethod(QGraphicsScene.ItemIndexMethod.NoIndex)
         self.selectionChanged.connect(self.slot_selectionChanged)
 
     def getDevicePixelRatioF(self):


### PR DESCRIPTION
Under certain circumstances Carla would crash when frequent updates on
the QGraphicsScene occurred, especially in combination with scrolling or
panning by the user. Backtraces showed either a segfault in
QGraphicsItem::parentItem() or around
QGraphicsSceneBspTree::climbTree(). While the first trace points towards
missing calls to pepareGeometryChange() in combination with custom
boundingRect() methods, inserting these did not yield a positive change,
though people with this issue also had success in disabling the
ItemIndexingMethod of their QGraphicsScene[0][1]. Setting this to
NoIndex solves this problem.

The original problem is reproducible with an ever-reconnecting client:

$ while true; do klick 120 & (sleep 0.1; killall klick); done

[0] https://bugreports.qt.io/browse/QTBUG-18021?focusedCommentId=367566&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-367566
[1] https://forum.qt.io/topic/71316/qgraphicsscenefinditembsptreevisitor-visit-crashes-due-to-an-obsolete-paintevent-after-qgraphicsscene-removeitem