### PR TITLE
JSFX value updates

### DIFF
--- a/source/backend/plugin/CarlaPluginJSFX.cpp
+++ b/source/backend/plugin/CarlaPluginJSFX.cpp
@@ -22,6 +22,7 @@
 #include "CarlaEngine.hpp"
 #include "CarlaJsfxUtils.hpp"
 #include "CarlaBackendUtils.hpp"
+#include "CarlaScopeUtils.hpp"
 #include "CarlaUtils.hpp"
 
 #include "water/files/File.h"
@@ -287,8 +288,11 @@ public:
             | JsusFx::kCompileFlag_CompileSerializeSection
             ;
 
-        if (!fEffect->compile(*fPathLibrary, fFilename, compileFlags))
-            carla_stderr("Failed to compile JSFX");
+        {
+            const CarlaScopedLocale csl;
+            if (!fEffect->compile(*fPathLibrary, fFilename, compileFlags))
+                carla_stderr("Failed to compile JSFX");
+        }
 
         // initialize the block size and sample rate
         // loading the chunk can invoke @slider which makes computations based on these
@@ -854,10 +858,13 @@ public:
         // ---------------------------------------------------------------
         // get info
 
-        if (!fEffect->readHeader(*fPathLibrary, filename))
         {
-            pData->engine->setLastError("Cannot read the JSFX header");
-            return false;
+            const CarlaScopedLocale csl;
+            if (!fEffect->readHeader(*fPathLibrary, filename))
+            {
+                pData->engine->setLastError("Cannot read the JSFX header");
+                return false;
+            }
         }
 
         // jsusfx lacks validity checks currently,

--- a/source/backend/plugin/CarlaPluginJSFX.cpp
+++ b/source/backend/plugin/CarlaPluginJSFX.cpp
@@ -290,6 +290,10 @@ public:
         if (!fEffect->compile(*fPathLibrary, fFilename, compileFlags))
             carla_stderr("Failed to compile JSFX");
 
+        // initialize the block size and sample rate
+        // loading the chunk can invoke @slider which makes computations based on these
+        fEffect->prepare(pData->engine->getSampleRate(), pData->engine->getBufferSize());
+
         // NOTE: count can be -1 in case of "none"
         uint32_t aIns = (fEffect->numInputs == -1) ? 0 : (uint32_t)fEffect->numInputs;
         uint32_t aOuts = (fEffect->numOutputs == -1) ? 0 : (uint32_t)fEffect->numOutputs;

--- a/source/backend/plugin/CarlaPluginJSFX.cpp
+++ b/source/backend/plugin/CarlaPluginJSFX.cpp
@@ -226,10 +226,12 @@ public:
         CARLA_SAFE_ASSERT_RETURN(fEffect != nullptr,);
         CARLA_SAFE_ASSERT_RETURN(parameterId < pData->param.count,);
 
-        JsusFx_Slider& slider = fEffect->sliders[pData->param.data[parameterId].rindex];
-        slider.setValue(value);
+        int32_t sliderIndex = pData->param.data[parameterId].rindex;
+        fEffect->moveSlider(sliderIndex, value);
 
-        CarlaPlugin::setParameterValue(parameterId, slider.getValue(), sendGui, sendOsc, sendCallback);
+        const JsusFx_Slider& slider = fEffect->sliders[sliderIndex];
+        float newValue = slider.getValue();
+        CarlaPlugin::setParameterValue(parameterId, newValue, sendGui, sendOsc, sendCallback);
     }
 
     void setParameterValueRT(const uint32_t parameterId, const float value, const bool sendCallbackLater) noexcept override
@@ -237,10 +239,12 @@ public:
         CARLA_SAFE_ASSERT_RETURN(fEffect != nullptr,);
         CARLA_SAFE_ASSERT_RETURN(parameterId < pData->param.count,);
 
-        JsusFx_Slider& slider = fEffect->sliders[pData->param.data[parameterId].rindex];
-        slider.setValue(value);
+        int32_t sliderIndex = pData->param.data[parameterId].rindex;
+        fEffect->moveSlider(sliderIndex, value);
 
-        CarlaPlugin::setParameterValueRT(parameterId, slider.getValue(), sendCallbackLater);
+        const JsusFx_Slider& slider = fEffect->sliders[sliderIndex];
+        float newValue = slider.getValue();
+        CarlaPlugin::setParameterValueRT(parameterId, newValue, sendCallbackLater);
     }
 
     void setChunkData(const void* data, std::size_t dataSize) override

--- a/source/backend/plugin/CarlaPluginJSFX.cpp
+++ b/source/backend/plugin/CarlaPluginJSFX.cpp
@@ -268,7 +268,7 @@ public:
     {
         CARLA_SAFE_ASSERT_RETURN(pData->engine != nullptr,);
         CARLA_SAFE_ASSERT_RETURN(fEffect != nullptr,);
-        carla_debug("CarlaPluginHSFX::reload()");
+        carla_debug("CarlaPluginJSFX::reload()");
 
         const EngineProcessMode processMode(pData->engine->getProccessMode());
 

--- a/source/backend/utils/CachedPlugins.cpp
+++ b/source/backend/utils/CachedPlugins.cpp
@@ -20,6 +20,7 @@
 #include "CarlaNative.h"
 #include "CarlaString.hpp"
 #include "CarlaBackendUtils.hpp"
+#include "CarlaScopeUtils.hpp"
 #include "CarlaLv2Utils.hpp"
 #include "CarlaJsfxUtils.hpp"
 
@@ -673,10 +674,13 @@ static const CarlaCachedPluginInfo* get_cached_plugin_jsfx(const water::File& fi
     name = file.getFileNameWithoutExtension().toRawUTF8();
     filename = file.getFullPathName().toRawUTF8();
 
-    if (!effect.readHeader(pathLibrary, filename.buffer()))
     {
-        info.valid = false;
-        return &info;
+        const CarlaScopedLocale csl;
+        if (!effect.readHeader(pathLibrary, filename.buffer()))
+        {
+            info.valid = false;
+            return &info;
+        }
     }
     if (effect.desc[0] == '\0')
     {

--- a/source/discovery/carla-discovery.cpp
+++ b/source/discovery/carla-discovery.cpp
@@ -18,6 +18,7 @@
 #include "CarlaBackendUtils.hpp"
 #include "CarlaLibUtils.hpp"
 #include "CarlaMathUtils.hpp"
+#include "CarlaScopeUtils.hpp"
 #include "CarlaMIDI.h"
 #include "LinkedList.hpp"
 
@@ -1689,10 +1690,13 @@ static void do_jsfx_check(const char* const filename, bool doInit)
             JsusFx::kCompileFlag_CompileSerializeSection |
             JsusFx::kCompileFlag_CompileGraphicsSection;
 
-        if (!effect.compile(pathLibrary, filename, compileFlags))
         {
-            DISCOVERY_OUT("error", "Cannot compile the JSFX plugin");
-            return;
+            const CarlaScopedLocale csl;
+            if (!effect.compile(pathLibrary, filename, compileFlags))
+            {
+                DISCOVERY_OUT("error", "Cannot compile the JSFX plugin");
+                return;
+            }
         }
 
 #if 0 // TODO(jsfx) when supporting custom graphics
@@ -1703,6 +1707,7 @@ static void do_jsfx_check(const char* const filename, bool doInit)
     }
     else
     {
+        const CarlaScopedLocale csl;
         if (!effect.readHeader(pathLibrary, filename))
         {
             DISCOVERY_OUT("error", "Cannot read the JSFX header");

--- a/source/modules/jsusfx/source/jsusfx.cpp
+++ b/source/modules/jsusfx/source/jsusfx.cpp
@@ -996,6 +996,7 @@ void JsusFx::prepare(int sampleRate, int blockSize) {
     *srate = (double) sampleRate;
     *samplesblock = blockSize;
     NSEEL_code_execute(codeInit);
+    computeSlider = true;
 }
 
 void JsusFx::moveSlider(int idx, float value, int normalizeSlider) {

--- a/source/modules/jsusfx/source/jsusfx.cpp
+++ b/source/modules/jsusfx/source/jsusfx.cpp
@@ -35,7 +35,7 @@
 #define AUTOVARV(name,value) name = NSEEL_VM_regvar(m_vm, #name); *name = value
 
 #define EEL_STRING_GET_CONTEXT_POINTER(opaque) (((JsusFx *)opaque)->m_string_context)
-#ifdef EEL_STRING_STDOUT_WRITE
+#ifndef EEL_STRING_STDOUT_WRITE
   #ifndef EELSCRIPT_NO_STDIO
     #define EEL_STRING_STDOUT_WRITE(x,len) { fwrite(x,len,1,stdout); fflush(stdout); }
   #endif


### PR DESCRIPTION
This fix is for a variety of parameter update problems.

- After a change of slider, a flag must be set in the effect such that `@slider` is invoked on the next cycle. The new code uses the method `moveSlider`, which sets this flag.
- Set the sample rate early, before activate, such that the `@slider` code will see the value instead of 0, when it's invoked as part of `setChunkData`
- Set `@slider` update flag after a change of sample rate (jsusfx problem)

Edit
- set the scoped locale everywhere, before steps which involve parsing (compile / read header)