### PR TITLE
JSFX misc

### DIFF
--- a/source/backend/plugin/CarlaPluginJSFX.cpp
+++ b/source/backend/plugin/CarlaPluginJSFX.cpp
@@ -283,18 +283,6 @@ public:
 
         // ---------------------------------------------------------------
 
-        // TODO(jsfx) uncomment when implementing these features
-        const int compileFlags = 0
-            //| JsusFx::kCompileFlag_CompileGraphicsSection
-            | JsusFx::kCompileFlag_CompileSerializeSection
-            ;
-
-        {
-            const CarlaScopedLocale csl;
-            if (!fEffect->compile(*fPathLibrary, fFilename, compileFlags))
-                carla_stderr("Failed to compile JSFX");
-        }
-
         // initialize the block size and sample rate
         // loading the chunk can invoke @slider which makes computations based on these
         fEffect->prepare(pData->engine->getSampleRate(), pData->engine->getBufferSize());
@@ -910,9 +898,16 @@ public:
 
         {
             const CarlaScopedLocale csl;
-            if (!fEffect->readHeader(*fPathLibrary, fFilename))
+
+            // TODO(jsfx) uncomment when implementing these features
+            const int compileFlags = 0
+                //| JsusFx::kCompileFlag_CompileGraphicsSection
+                | JsusFx::kCompileFlag_CompileSerializeSection
+                ;
+
+            if (!fEffect->compile(*fPathLibrary, fFilename, compileFlags))
             {
-                pData->engine->setLastError("Cannot read the JSFX header");
+                pData->engine->setLastError("Failed to compile JSFX");
                 return false;
             }
         }


### PR DESCRIPTION
This corrects a pair of issues in the JSFX implementation. #1487

- [x] the source should be compiled once only, so that I/O ports are stable
  Not recompiling might cause the plugin to be not clean as new after just calling an `@init` (by `fEffect->prepare`); this can be left to the script programmer after all.

- [x] plugin `getLabel` would not return the proper value, it was a leftover from before, when using full paths as label rather than a relative path fragment. Replaced the path `fFilename` with the 2-part identifier. (`CarlaJsfxUnit`)

Ok for merging.