### PR TITLE
jsfx: parse the pseudo-tags for maker and category

### DIFF
--- a/source/backend/utils/CachedPlugins.cpp
+++ b/source/backend/utils/CachedPlugins.cpp
@@ -670,7 +670,8 @@ static const CarlaCachedPluginInfo* get_cached_plugin_jsfx(const CarlaJsfxUnit& 
     CarlaJsusFx effect(pathLibrary);
     effect.setQuiet(true);
 
-    static CarlaString name, label;
+    static CarlaString name, label, maker;
+    CB::PluginCategory category = CB::PLUGIN_CATEGORY_OTHER;
 
     const water::File unitFilePath = unit.getFilePath();
     label = unit.getFileId().toRawUTF8();
@@ -687,6 +688,15 @@ static const CarlaCachedPluginInfo* get_cached_plugin_jsfx(const CarlaJsfxUnit& 
     {
         info.valid = false;
         return &info;
+    }
+    {
+        water::String author;
+        if (!CarlaJsusFx::parsePseudoTags(unitFilePath, author, category))
+        {
+            info.valid = false;
+            return &info;
+        }
+        maker = author.toRawUTF8();
     }
 
     info.valid         = true;
@@ -711,7 +721,7 @@ static const CarlaCachedPluginInfo* get_cached_plugin_jsfx(const CarlaJsfxUnit& 
             ++info.parameterIns;
     }
 
-    info.category = CB::PLUGIN_CATEGORY_NONE;
+    info.category = category;
     info.hints    = 0;
 
 #if 0 // TODO(jsfx) when supporting custom graphics
@@ -722,7 +732,7 @@ static const CarlaCachedPluginInfo* get_cached_plugin_jsfx(const CarlaJsfxUnit& 
 
     info.name      = name.buffer();
     info.label     = label.buffer();
-    info.maker     = gCachedPluginsNullCharPtr;
+    info.maker     = maker.buffer();
     info.copyright = gCachedPluginsNullCharPtr;
 
     return &info;

--- a/source/discovery/carla-discovery.cpp
+++ b/source/discovery/carla-discovery.cpp
@@ -1704,6 +1704,15 @@ static void do_jsfx_check(const char* const filename, bool doInit)
         return;
     }
 
+    // extract author and category from the pseudo-tags
+    water::String author;
+    CB::PluginCategory category = CB::PLUGIN_CATEGORY_OTHER;
+    if (!CarlaJsusFx::parsePseudoTags(water::File(water::CharPointer_UTF8(filename)), author, category))
+    {
+        DISCOVERY_OUT("error", "Cannot scan the JSFX file for pseudo-tags");
+        return;
+    }
+
     // NOTE: count can be -1 in case of "none"
     uint32_t audioIns = (effect.numInputs == -1) ? 0 : (uint32_t)effect.numInputs;
     uint32_t audioOuts = (effect.numOutputs == -1) ? 0 : (uint32_t)effect.numOutputs;
@@ -1721,7 +1730,9 @@ static void do_jsfx_check(const char* const filename, bool doInit)
     DISCOVERY_OUT("init", "-----------");
     DISCOVERY_OUT("build", BINARY_NATIVE);
     DISCOVERY_OUT("hints", hints);
+    DISCOVERY_OUT("category", getPluginCategoryAsString(category));
     DISCOVERY_OUT("name", effect.desc);
+    DISCOVERY_OUT("maker", author);
     DISCOVERY_OUT("label", filename);
     DISCOVERY_OUT("audio.ins", audioIns);
     DISCOVERY_OUT("audio.outs", audioOuts);


### PR DESCRIPTION
This extracts commented metadata from jsfx files, and registers the author and category.
The functions which process this are utility implemented as part of carla, not the jsusfx library.