### PR TITLE
JSFX slider syntax fix for enums

### DIFF
--- a/source/backend/utils/CachedPlugins.cpp
+++ b/source/backend/utils/CachedPlugins.cpp
@@ -668,7 +668,7 @@ static const CarlaCachedPluginInfo* get_cached_plugin_jsfx(const CarlaJsfxUnit& 
     CarlaJsusFxPathLibrary pathLibrary(unit);
 
     CarlaJsusFx effect(pathLibrary);
-    effect.setQuiet(true);
+    effect.setMessagesQuiet(true);
 
     static CarlaString name, label;
 

--- a/source/discovery/carla-discovery.cpp
+++ b/source/discovery/carla-discovery.cpp
@@ -1671,7 +1671,7 @@ static void do_jsfx_check(const char* const filename, bool doInit)
     CarlaJsusFxPathLibrary pathLibrary(unit);
 
     CarlaJsusFx effect(pathLibrary);
-    effect.setQuiet(true);
+    effect.setMessagesQuiet(true);
 
     uint hints = 0;
 

--- a/source/modules/jsusfx/source/jsusfx.cpp
+++ b/source/modules/jsusfx/source/jsusfx.cpp
@@ -375,13 +375,17 @@ bool JsusFx_Slider::config(JsusFx &fx, const int index, const char *param, const
 						
 						if ( *tmp == '}' )
 						{
+							tmp++;
 							break;
 						}
-						
+						// closing '}' is not required, so be permissive here
+						if ( *tmp == '>' )
+						{
+							break;
+						}
+
 						tmp++;
 					}
-					
-					tmp++;
 				}
 			}
 		}

--- a/source/utils/CarlaJsfxUtils.hpp
+++ b/source/utils/CarlaJsfxUtils.hpp
@@ -48,14 +48,19 @@ public:
     {
     }
 
-    void setQuiet(bool quiet)
+    void setMessagesQuiet(bool quiet)
     {
-        fQuiet = quiet;
+        fMessagesQuiet = quiet;
+    }
+
+    void setErrorsQuiet(bool quiet)
+    {
+        fErrorsQuiet = quiet;
     }
 
     void displayMsg(const char* fmt, ...) override
     {
-        if (!fQuiet)
+        if (!fMessagesQuiet)
         {
             char msgBuf[256];
             ::va_list args;
@@ -69,7 +74,7 @@ public:
 
     void displayError(const char* fmt, ...) override
     {
-        if (!fQuiet)
+        if (!fErrorsQuiet)
         {
             char msgBuf[256];
             ::va_list args;
@@ -82,7 +87,8 @@ public:
     }
 
 private:
-    bool fQuiet = false;
+    bool fMessagesQuiet = false;
+    bool fErrorsQuiet = false;
 };
 
 // -------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Some plugins that ship in Reaper (6 of them) would not scan because the syntax of Reaper is more permissive.
Example: `schwa/midi_modal_randomness`

One can omit the closing brace from the slider line.
`slider1:0<0,11,{1,1.5,2,2.5,3,4,4.5,5,5.5,6,6.5,7>Interval A`

This modifies jsusfx accordingly.