### PR TITLE
jsfx: fix various MIDI issues

### DIFF
--- a/source/modules/jsusfx/source/jsusfx.cpp
+++ b/source/modules/jsusfx/source/jsusfx.cpp
@@ -1132,9 +1132,6 @@ void JsusFx::setTransportValues(
 bool JsusFx::process(const float **input, float **output, int size, int numInputChannels, int numOutputChannels) {
     midiInputReadPos = 0;
     midiOutput.clear();
-	
-    if ( codeSample == NULL )
-        return false;
 
     if ( computeSlider ) {
         NSEEL_code_execute(codeSlider);
@@ -1146,12 +1143,15 @@ bool JsusFx::process(const float **input, float **output, int size, int numInput
     *samplesblock = size;
     *num_ch = numValidInputChannels;
     NSEEL_code_execute(codeBlock);
-    for(int i=0;i<size;i++) {
-    	for (int c = 0; c < numInputChannels; ++c)
-        	*spl[c] = input[c][i];
-        NSEEL_code_execute(codeSample);
-    	for (int c = 0; c < numOutputChannels; ++c)
-        	output[c][i] = *spl[c];
+
+    if (codeSample) {
+        for(int i=0;i<size;i++) {
+            for (int c = 0; c < numInputChannels; ++c)
+                *spl[c] = input[c][i];
+            NSEEL_code_execute(codeSample);
+            for (int c = 0; c < numOutputChannels; ++c)
+                output[c][i] = *spl[c];
+        }
     }
 	
 	midiInput.clear();
@@ -1162,9 +1162,6 @@ bool JsusFx::process(const float **input, float **output, int size, int numInput
 bool JsusFx::process64(const double **input, double **output, int size, int numInputChannels, int numOutputChannels) {
     midiInputReadPos = 0;
     midiOutput.clear();
-	
-    if ( codeSample == NULL )
-        return false;
 
     if ( computeSlider ) {
         NSEEL_code_execute(codeSlider);
@@ -1176,12 +1173,15 @@ bool JsusFx::process64(const double **input, double **output, int size, int numI
     *samplesblock = size;
     *num_ch = numValidInputChannels;
     NSEEL_code_execute(codeBlock);
-    for(int i=0;i<size;i++) {
-    	for (int c = 0; c < numInputChannels; ++c)
-        	*spl[c] = input[c][i];
-        NSEEL_code_execute(codeSample);
-    	for (int c = 0; c < numOutputChannels; ++c)
-        	output[c][i] = *spl[c];
+
+    if (codeSample) {
+        for(int i=0;i<size;i++) {
+            for (int c = 0; c < numInputChannels; ++c)
+                *spl[c] = input[c][i];
+            NSEEL_code_execute(codeSample);
+            for (int c = 0; c < numOutputChannels; ++c)
+                output[c][i] = *spl[c];
+        }
     }
 	
 	midiInput.clear();

--- a/source/modules/jsusfx/source/jsusfx_file.cpp
+++ b/source/modules/jsusfx/source/jsusfx_file.cpp
@@ -132,6 +132,7 @@ static EEL_F NSEEL_CGEN_CALL _file_mem(void *opaque, EEL_F *_handle, EEL_F *_des
 	
 	const int destOffset = (int)(*_destOffset + 0.001);
 	
+	//TODO(jpc) verify this; suspicious use of RAM pointer, limits not checked
 	EEL_F * dest = NSEEL_VM_getramptr(jsusFx.m_vm, destOffset, nullptr);
 	
 	if (dest == nullptr)


### PR DESCRIPTION
This gets more MIDI plugins to work correctly. The changes are as follows:
- implement the missing API `midirecv_buf`
- fixes the implementation of `midisend_buf`, which is horrifyingly wrong
- allows to run FX which do not have `@sample` processing code, only `@block` (MIDI-only fx)