### PR TITLE
jsfx: parse more forms of sliders

### DIFF
--- a/source/backend/plugin/CarlaPluginJSFX.cpp
+++ b/source/backend/plugin/CarlaPluginJSFX.cpp
@@ -395,6 +395,15 @@ public:
             bool isEnum = slider.isEnum && min == 0.0f && max >= 0.0f &&
                 max + 1.0f == (float)slider.enumNames.size();
 
+            // NOTE: in case of incomplete slider specification without <min,max,step>;
+            //  these are usually output-only sliders.
+            if (min == max)
+            {
+                // replace with a dummy range
+                min = 0.0f;
+                max = 1.0f;
+            }
+
             if (min > max)
                 std::swap(min, max);
 

--- a/source/modules/jsusfx/source/jsusfx.cpp
+++ b/source/modules/jsusfx/source/jsusfx.cpp
@@ -362,8 +362,9 @@ bool JsusFx_Slider::config(JsusFx &fx, const int index, const char *param, const
 	
 	if ( *tmp != '<' )
 	{
-		fx.displayError("slider info is missing");
-		return false;
+		//NOTE(jpc) slider without <> section, handle it permissively
+		/*fx.displayError("slider info is missing");
+		return false;*/
 	}
 	else
 	{

--- a/source/modules/jsusfx/source/jsusfx.cpp
+++ b/source/modules/jsusfx/source/jsusfx.cpp
@@ -323,18 +323,14 @@ bool JsusFx_Slider::config(JsusFx &fx, const int index, const char *param, const
 	isEnum = false;
 	
 	bool hasName = false;
-
-	const char *tmp = strchr(buffer, '>');
-	if ( tmp != NULL ) {
-		tmp++;
-		while (*tmp == ' ')
-			tmp++;
-		strncpy(desc, tmp, 64);
-		tmp = 0;
-	} else {
-		desc[0] = 0;
-	}
 	
+	const char *tmp = nextToken(buffer);
+	for (const char *next; *(next = nextToken(tmp)); ) {
+		tmp = (tmp == next) ? (tmp + 1) : next;
+	}
+	strncpy(desc, tmp, 64);
+	desc[63] = '\0';
+
 	tmp = buffer;
 	
 	if ( isalpha(*tmp) ) {

--- a/source/modules/jsusfx/source/jsusfx.cpp
+++ b/source/modules/jsusfx/source/jsusfx.cpp
@@ -314,6 +314,7 @@ static const char *nextToken(const char *text) {
 bool JsusFx_Slider::config(JsusFx &fx, const int index, const char *param, const int lnumber) {
 	char buffer[2048];
 	strncpy(buffer, param, 2048);
+	buffer[sizeof(buffer)-1] = '\0';
 	
 	def = min = max = inc = 0;
 	exists = false;


### PR DESCRIPTION
This enables to run more jsfx plugins.
example: `loser/DDC` (Digital Drum Compressor)

These files have an unspecified slider notation which omits the `<>` part.
eg. `slider10:0,Reduction (dB)`

These sliders without a range are given a default [0;1].
The scope of this PR does not extend to output control automations, which will be for a next one.