### PR TITLE
jsfx: output parameter changes

### DIFF
--- a/source/backend/plugin/CarlaPluginJSFX.cpp
+++ b/source/backend/plugin/CarlaPluginJSFX.cpp
@@ -300,6 +300,7 @@ public:
             pData->audioOut.createNew(aOuts);
         }
 
+        // count the sliders and establish the mappings between parameter and slider
         uint32_t params = 0;
         uint32_t mapOfParameterToSlider[JsusFx::kMaxSliders];
         for (uint32_t sliderIndex = 0; sliderIndex < JsusFx::kMaxSliders; ++sliderIndex)
@@ -308,7 +309,12 @@ public:
             if (slider.exists)
             {
                 mapOfParameterToSlider[params] = sliderIndex;
+                slider.userData = params;
                 ++params;
+            }
+            else
+            {
+                slider.userData = -1;
             }
         }
 
@@ -827,11 +833,12 @@ public:
         {
             for (int sliderIndex = 0; sliderIndex < JsusFx::kMaxSliders; ++sliderIndex)
             {
-                if (fEffect->sliderHasChanged(sliderIndex))
+                JsusFx_Slider& slider = fEffect->sliders[sliderIndex];
+                if (slider.exists && fEffect->sliderHasChanged(sliderIndex))
                 {
-                    carla_stderr(
-                        "JSFX slider change %d: %f\n",
-                        sliderIndex, *fEffect->sliders[sliderIndex].owner);
+                    uint32_t parameterIndex = (uint32_t)slider.userData;
+                    float newValue = slider.getValue();
+                    setParameterValueRT(parameterIndex, newValue, true);
                 }
             }
         }

--- a/source/backend/plugin/CarlaPluginJSFX.cpp
+++ b/source/backend/plugin/CarlaPluginJSFX.cpp
@@ -395,6 +395,15 @@ public:
             bool isEnum = slider.isEnum && min == 0.0f && max >= 0.0f &&
                 max + 1.0f == (float)slider.enumNames.size();
 
+            // NOTE: in case of incomplete slider specification without <min,max,step>;
+            //  these are usually output-only sliders.
+            if (min == max)
+            {
+                // replace with a dummy range
+                min = 0.0f;
+                max = 1.0f;
+            }
+
             if (min > max)
                 std::swap(min, max);
 

--- a/source/backend/plugin/CarlaPluginJSFX.cpp
+++ b/source/backend/plugin/CarlaPluginJSFX.cpp
@@ -819,6 +819,22 @@ public:
             }
 
         } // End of MIDI Output
+
+        // --------------------------------------------------------------------------------------------------------
+        // Control Output
+
+        if (fEffect->hasSliderChanges())
+        {
+            for (int sliderIndex = 0; sliderIndex < JsusFx::kMaxSliders; ++sliderIndex)
+            {
+                if (fEffect->sliderHasChanged(sliderIndex))
+                {
+                    carla_stderr(
+                        "JSFX slider change %d: %f\n",
+                        sliderIndex, *fEffect->sliders[sliderIndex].owner);
+                }
+            }
+        }
     }
 
     // -------------------------------------------------------------------

--- a/source/modules/jsusfx/source/jsusfx.cpp
+++ b/source/modules/jsusfx/source/jsusfx.cpp
@@ -362,8 +362,9 @@ bool JsusFx_Slider::config(JsusFx &fx, const int index, const char *param, const
 	
 	if ( *tmp != '<' )
 	{
-		fx.displayError("slider info is missing");
-		return false;
+		//NOTE(jpc) slider without <> section, handle it permissively
+		/*fx.displayError("slider info is missing");
+		return false;*/
 	}
 	else
 	{

--- a/source/modules/jsusfx/source/jsusfx.cpp
+++ b/source/modules/jsusfx/source/jsusfx.cpp
@@ -323,18 +323,14 @@ bool JsusFx_Slider::config(JsusFx &fx, const int index, const char *param, const
 	isEnum = false;
 	
 	bool hasName = false;
-
-	const char *tmp = strchr(buffer, '>');
-	if ( tmp != NULL ) {
-		tmp++;
-		while (*tmp == ' ')
-			tmp++;
-		strncpy(desc, tmp, 64);
-		tmp = 0;
-	} else {
-		desc[0] = 0;
-	}
 	
+	const char *tmp = nextToken(buffer);
+	for (const char *next; *(next = nextToken(tmp)); ) {
+		tmp = (tmp == next) ? (tmp + 1) : next;
+	}
+	strncpy(desc, tmp, 64);
+	desc[63] = '\0';
+
 	tmp = buffer;
 	
 	if ( isalpha(*tmp) ) {

--- a/source/modules/jsusfx/source/jsusfx.cpp
+++ b/source/modules/jsusfx/source/jsusfx.cpp
@@ -314,6 +314,7 @@ static const char *nextToken(const char *text) {
 bool JsusFx_Slider::config(JsusFx &fx, const int index, const char *param, const int lnumber) {
 	char buffer[2048];
 	strncpy(buffer, param, 2048);
+	buffer[sizeof(buffer)-1] = '\0';
 	
 	def = min = max = inc = 0;
 	exists = false;

--- a/source/modules/jsusfx/source/jsusfx.h
+++ b/source/modules/jsusfx/source/jsusfx.h
@@ -66,6 +66,8 @@ public:
     std::vector<std::string> enumNames;
     bool isEnum;
 
+	intptr_t userData;
+
     JsusFx_Slider() {
         def = min = max = inc = 0;
         name[0] = 0;
@@ -73,6 +75,7 @@ public:
         exists = false;
         owner = nullptr;
         isEnum = false;
+        userData = 0;
     }
 
     bool config(JsusFx &fx, const int index, const char *param, const int lnumber);


### PR DESCRIPTION
Followup to #1516 which updates output parameters.

Implements Reaper API `sliderchange`.
It accepts either a bitmap or a slider as the argument, which lead to different behavior in each case.
To make that work efficiently, it needs a mapping from variable (EEL_F*) to slider, which is introduced as a hash table.

This involves a bitmap of changed sliders, and 1-indexing weirdness.
Added a few comments to clarify.