### PR TITLE
detect pipewire jack backend for better defaults

### DIFF
--- a/source/frontend/carla_shared.py
+++ b/source/frontend/carla_shared.py
@@ -299,7 +299,7 @@ if WINDOWS:
     CARLA_DEFAULT_AUDIO_DRIVER = "DirectSound"
 elif MACOS:
     CARLA_DEFAULT_AUDIO_DRIVER = "CoreAudio"
-elif os.path.exists("/usr/bin/jackd") or os.path.exists("/usr/bin/jackdbus"):
+elif os.path.exists("/usr/bin/jackd") or os.path.exists("/usr/bin/jackdbus") or os.path.exists("/usr/bin/pw-jack"):
     CARLA_DEFAULT_AUDIO_DRIVER = "JACK"
 else:
     CARLA_DEFAULT_AUDIO_DRIVER = "PulseAudio"


### PR DESCRIPTION
These days there is pipewire, which provides backends for PulseAudio, ALSA and JACK. Usually, if one is using pipewire as a replacement for the former three, they want to run Carla with the JACK backend mode since it is the most compatible and allows managing pipewire connections.

If the pipewire jack backend is installed can be detected by checking if `/usr/bin/pw-jack` exists, so I added it to the check.