### PR TITLE
Cast QDial value parameter to prevent type error

### DIFF
--- a/source/frontend/widgets/scalabledial.py
+++ b/source/frontend/widgets/scalabledial.py
@@ -270,7 +270,7 @@ class ScalableDial(QDial):
             self.fRealValue = self.fMinimum
 
         elif value >= self.fMaximum:
-            qtValue = self.fPrecision
+            qtValue = int(self.fPrecision)
             self.fRealValue = self.fMaximum
 
         else:


### PR DESCRIPTION
Fixes this error, which would occur after `setPrecision` had been called
with a non-integer value.

```
Traceback (most recent call last):
  File "/usr/share/carla/carla_host.py", line 1442, in slot_handlePluginAddedCallback
    pitem = self.ui.listWidget.createItem(pluginId, self.fSavedSettings[CARLA_KEY_MAIN_CLASSIC_SKIN])
  File "/usr/share/carla/widgets/racklistwidget.py", line 241, in createItem
    return RackListItem(self, pluginId, useClassicSkin)
  File "/usr/share/carla/widgets/racklistwidget.py", line 86, in __init__
    self.recreateWidget(firstInit = True)
  File "/usr/share/carla/widgets/racklistwidget.py", line 176, in recreateWidget
    self.fWidget = createPluginSlot(self.fParent, self.host, self.fPluginId, self.fOptions)
  File "/usr/share/carla/carla_skin.py", line 2090, in createPluginSlot
    return PluginSlot_Default(parent, host, pluginId, skinColor, skinStyle)
  File "/usr/share/carla/carla_skin.py", line 1766, in __init__
    self.ready()
  File "/usr/share/carla/carla_skin.py", line 642, in ready
    paramWidget.setValue(self.host.get_internal_parameter_value(self.fPluginId, paramIndex))
  File "/usr/share/carla/widgets/scalabledial.py", line 282, in setValue
    QDial.setValue(self, qtValue)
TypeError: setValue(self, int): argument 2 has unexpected type 'float'
Error mapping plugin to canvas client: 16 Step Sequencer
```