### PR TITLE
Fix type error in signal emission

### DIFF
--- a/source/frontend/patchcanvas/canvasbox.py
+++ b/source/frontend/patchcanvas/canvasbox.py
@@ -411,7 +411,7 @@ class CanvasBox(QGraphicsObject):
             connection.widget.setZValue(z_value)
 
     def triggerSignalPositionChanged(self):
-        self.positionChanged.emit(self.m_group_id, self.m_split, self.x(), self.y())
+        self.positionChanged.emit(self.m_group_id, self.m_split, int(self.x()), int(self.y()))
         self.m_will_signal_pos_change = False
 
     @pyqtSlot()


### PR DESCRIPTION
The `CanvasBox.positionChanged` signal expects to receive `x` and `y` as
`int`s, but they were being passed as `float`s, which were mangled at the
receiving signal handler.

This manifested as huge `x` and `y` values for canvas boxes, and when
saving and loading projects all boxes would hit the edge of the canvas
and get placed at the extreme edge.