### PR TITLE
Fix inaccurate midi CC rounding

### DIFF
--- a/source/backend/engine/CarlaEngineData.cpp
+++ b/source/backend/engine/CarlaEngineData.cpp
@@ -50,7 +50,7 @@ uint8_t EngineControlEvent::convertToMidiData(const uint8_t channel, uint8_t dat
             if (midiValue >= 0)
                 data[2] = uint8_t(midiValue);
             else
-                data[2] = uint8_t(carla_fixedValue<float>(0.0f, 1.0f, normalizedValue) * static_cast<float>(MAX_MIDI_VALUE-1));
+                data[2] = uint8_t(carla_fixedValue<float>(0.0f, 1.0f, normalizedValue) * static_cast<float>(MAX_MIDI_VALUE-1) + 0.5f);
         }
         return 3;
 

--- a/source/backend/plugin/CarlaPluginBridge.cpp
+++ b/source/backend/plugin/CarlaPluginBridge.cpp
@@ -1580,7 +1580,7 @@ public:
                             fShmRtClientControl.writeByte(3); // size
                             fShmRtClientControl.writeByte(uint8_t(MIDI_STATUS_CONTROL_CHANGE | (event.channel & MIDI_CHANNEL_BIT)));
                             fShmRtClientControl.writeByte(uint8_t(ctrlEvent.param));
-                            fShmRtClientControl.writeByte(uint8_t(ctrlEvent.normalizedValue*127.0f));
+                            fShmRtClientControl.writeByte(uint8_t(ctrlEvent.normalizedValue*127.0f + 0.5f));
                         }
                         break;
                     }

--- a/source/backend/plugin/CarlaPluginFluidSynth.cpp
+++ b/source/backend/plugin/CarlaPluginFluidSynth.cpp
@@ -1304,7 +1304,7 @@ public:
 
                         if ((pData->options & PLUGIN_OPTION_SEND_CONTROL_CHANGES) != 0 && ctrlEvent.param < MAX_MIDI_VALUE)
                         {
-                            fluid_synth_cc(fSynth, event.channel, ctrlEvent.param, int(ctrlEvent.normalizedValue*127.0f));
+                            fluid_synth_cc(fSynth, event.channel, ctrlEvent.param, int(ctrlEvent.normalizedValue*127.0f + 0.5f));
                         }
                         break;
                     }

--- a/source/backend/plugin/CarlaPluginJack.cpp
+++ b/source/backend/plugin/CarlaPluginJack.cpp
@@ -1134,7 +1134,7 @@ public:
                             fShmRtClientControl.writeByte(3); // size
                             fShmRtClientControl.writeByte(uint8_t(MIDI_STATUS_CONTROL_CHANGE | (event.channel & MIDI_CHANNEL_BIT)));
                             fShmRtClientControl.writeByte(uint8_t(ctrlEvent.param));
-                            fShmRtClientControl.writeByte(uint8_t(ctrlEvent.normalizedValue*127.0f));
+                            fShmRtClientControl.writeByte(uint8_t(ctrlEvent.normalizedValue*127.0f + 0.5f));
                         }
                         break;
 

--- a/source/backend/plugin/CarlaPluginJuce.cpp
+++ b/source/backend/plugin/CarlaPluginJuce.cpp
@@ -1151,7 +1151,7 @@ public:
                             uint8_t midiData[3];
                             midiData[0] = uint8_t(MIDI_STATUS_CONTROL_CHANGE | (event.channel & MIDI_CHANNEL_BIT));
                             midiData[1] = uint8_t(ctrlEvent.param);
-                            midiData[2] = uint8_t(ctrlEvent.normalizedValue*127.0f);
+                            midiData[2] = uint8_t(ctrlEvent.normalizedValue*127.0f + 0.5f);
 
                             fMidiBuffer.addEvent(midiData, 3, static_cast<int>(event.time));
                         }
@@ -1173,7 +1173,7 @@ public:
                             fMidiBuffer.addEvent(midiData, 3, static_cast<int>(event.time));
 
                             midiData[1] = MIDI_CONTROL_BANK_SELECT__LSB;
-                            midiData[2] = uint8_t(ctrlEvent.normalizedValue*127.0f);
+                            midiData[2] = uint8_t(ctrlEvent.normalizedValue*127.0f + 0.5f);
                             fMidiBuffer.addEvent(midiData, 3, static_cast<int>(event.time));
                         }
                         break;
@@ -1190,7 +1190,7 @@ public:
                         {
                             uint8_t midiData[3];
                             midiData[0] = uint8_t(MIDI_STATUS_PROGRAM_CHANGE | (event.channel & MIDI_CHANNEL_BIT));
-                            midiData[1] = uint8_t(ctrlEvent.normalizedValue*127.0f);
+                            midiData[1] = uint8_t(ctrlEvent.normalizedValue*127.0f + 0.5f);
                             fMidiBuffer.addEvent(midiData, 2, static_cast<int>(event.time));
                         }
                         break;

--- a/source/backend/plugin/CarlaPluginLADSPADSSI.cpp
+++ b/source/backend/plugin/CarlaPluginLADSPADSSI.cpp
@@ -1732,7 +1732,7 @@ public:
                             seqEvent.type = SND_SEQ_EVENT_CONTROLLER;
                             seqEvent.data.control.channel = event.channel;
                             seqEvent.data.control.param   = ctrlEvent.param;
-                            seqEvent.data.control.value   = int8_t(ctrlEvent.normalizedValue*127.0f);
+                            seqEvent.data.control.value   = int8_t(ctrlEvent.normalizedValue*127.0f + 0.5f);
                         }
 
 #ifndef BUILD_BRIDGE_ALTERNATIVE_ARCH

--- a/source/backend/plugin/CarlaPluginLV2.cpp
+++ b/source/backend/plugin/CarlaPluginLV2.cpp
@@ -4092,7 +4092,7 @@ public:
                             uint8_t midiData[3];
                             midiData[0] = uint8_t(MIDI_STATUS_CONTROL_CHANGE | (event.channel & MIDI_CHANNEL_BIT));
                             midiData[1] = uint8_t(ctrlEvent.param);
-                            midiData[2] = uint8_t(ctrlEvent.normalizedValue*127.0f);
+                            midiData[2] = uint8_t(ctrlEvent.normalizedValue*127.0f + 0.5f);
 
                             const uint32_t mtime(isSampleAccurate ? startTime : eventTime);
 

--- a/source/backend/plugin/CarlaPluginNative.cpp
+++ b/source/backend/plugin/CarlaPluginNative.cpp
@@ -2065,7 +2065,7 @@ public:
                             nativeEvent.time    = isSampleAccurate ? startTime : eventTime;
                             nativeEvent.data[0] = uint8_t(MIDI_STATUS_CONTROL_CHANGE | (event.channel & MIDI_CHANNEL_BIT));
                             nativeEvent.data[1] = uint8_t(ctrlEvent.param);
-                            nativeEvent.data[2] = uint8_t(ctrlEvent.normalizedValue*127.0f);
+                            nativeEvent.data[2] = uint8_t(ctrlEvent.normalizedValue*127.0f + 0.5f);
                             nativeEvent.size    = 3;
                         }
 

--- a/source/backend/plugin/CarlaPluginSFZero.cpp
+++ b/source/backend/plugin/CarlaPluginSFZero.cpp
@@ -471,7 +471,7 @@ public:
 
                         if ((pData->options & PLUGIN_OPTION_SEND_CONTROL_CHANGES) != 0 && ctrlEvent.param < MAX_MIDI_VALUE)
                         {
-                            fSynth.handleController(event.channel+1, ctrlEvent.param, int(ctrlEvent.normalizedValue*127.0f));
+                            fSynth.handleController(event.channel+1, ctrlEvent.param, int(ctrlEvent.normalizedValue*127.0f + 0.5f));
                         }
 
                         break;

--- a/source/backend/plugin/CarlaPluginVST2.cpp
+++ b/source/backend/plugin/CarlaPluginVST2.cpp
@@ -1502,7 +1502,7 @@ public:
                             vstMidiEvent.deltaFrames = static_cast<int32_t>(isSampleAccurate ? startTime : eventTime);
                             vstMidiEvent.midiData[0] = char(MIDI_STATUS_CONTROL_CHANGE | (event.channel & MIDI_CHANNEL_BIT));
                             vstMidiEvent.midiData[1] = char(ctrlEvent.param);
-                            vstMidiEvent.midiData[2] = char(ctrlEvent.normalizedValue*127.0f);
+                            vstMidiEvent.midiData[2] = char(ctrlEvent.normalizedValue*127.0f + 0.5f);
                         }
 
 #ifndef BUILD_BRIDGE_ALTERNATIVE_ARCH


### PR DESCRIPTION
This fixes the inaccuracies in midi controller values which are introduced by converting them to the float range 0.0 -- 1.0 and back again. The problem is that `int((18 / 127.0) * 127.0) != 18`. (it's 17, because the float result is something like 17.9999998)

It can be fixed by properly rounding to the nearest integer, instead of rounding down. This is accomplished by the usual "add 0.5" trick.

`modules/sfzero/sfzero/SFZ{Synth,Voice}.cpp` exhibit a similar problem, but were not touched in this PR, because they're not part of the engine and we might want to stay bug-to-bug compatible with the upstream plugin.

This might resolve #1249 and might resolve #899.