### PR TITLE
add riscv64 support

### DIFF
--- a/source/Makefile.deps.mk
+++ b/source/Makefile.deps.mk
@@ -81,6 +81,10 @@ ifneq (,$(filter aarch64%,$(TARGET_PROCESSOR)))
 CPU_AARCH64 = true
 CPU_ARM_OR_AARCH64 = true
 endif
+ifneq (,$(filter riscv64%,$(TARGET_PROCESSOR)))
+CPU_RISCV64 = true
+CPU_RISCV32_OR_RISCV64 = true
+endif
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Set PKG_CONFIG (can be overridden by environment variable)

--- a/source/modules/ysfx/Makefile
+++ b/source/modules/ysfx/Makefile
@@ -27,15 +27,19 @@ YSFX_FLAGS += -Wno-sign-compare
 YSFX_FLAGS += -Wno-unused-function
 YSFX_FLAGS += -Wno-unused-parameter
 
-ifeq ($(CPU_ARM),true)
-ifneq ($(CPU_ARM64),true)
-# optimized assembly code for armhf does not run properly yet
-YSFX_FLAGS += -DEEL_TARGET_PORTABLE
-endif
+
+# ysfx/jsfx EEL has optimised code for i386, x86_64...
+ifeq ($(CPU_I386_OR_X86_64),true)
+YSFX_FTS_EEL_HAS_OPTIMISATIONS = true
 endif
 
-# RISC-V needs portable code
-ifeq ($(CPU_RISCV64),true)
+# ...and "optimized assembly code for armhf does not run properly yet", so only ARM64 is supported
+ifeq ($(CPU_ARM64),true)
+YSFX_FTS_EEL_HAS_OPTIMISATIONS = true
+endif
+
+ifneq ($(YSFX_FTS_EEL_HAS_OPTIMISATIONS),true)
+# turn on portable code for other architectures who don't have optimised code
 YSFX_FLAGS += -DEEL_TARGET_PORTABLE
 endif
 

--- a/source/modules/ysfx/Makefile
+++ b/source/modules/ysfx/Makefile
@@ -34,6 +34,11 @@ YSFX_FLAGS += -DEEL_TARGET_PORTABLE
 endif
 endif
 
+# RISC-V needs portable code
+ifeq ($(CPU_RISCV64),true)
+YSFX_FLAGS += -DEEL_TARGET_PORTABLE
+endif
+
 ifeq ($(YSFX_FTS_LACKS_LFS_SUPPORT),true)
 YSFX_FLAGS += -DYSFX_FTS_LACKS_LFS_SUPPORT
 endif


### PR DESCRIPTION
Currently, it's difficult for WDL eel to support riscv64 'natively', so we are enabling EEL_TARGET_PORTABLE as a workaround.