### PR TITLE
fix pkgconfig files having bad includedir/libdir variables

### DIFF
--- a/data/pkgconfig/carla-host-plugin.pc
+++ b/data/pkgconfig/carla-host-plugin.pc
@@ -1,9 +1,10 @@
 prefix=X-PREFIX-X
-libdir=X-LIBDIR-X/carla
-includedir=X-INCLUDEDIR-X/carla
+libdir=X-LIBDIR-X
+includedir=X-INCLUDEDIR-X
+carla_libdir=${libdir}/carla
 
 Name: carla-host-plugin
 Version: X-VERSION-X
 Description: Carla Host as Native Plugin
-Libs: -Wl,-rpath,${libdir} -L${libdir} -lcarla_host-plugin
-Cflags: -DREAL_BUILD -I${includedir} -I${includedir}/includes
+Libs: -Wl,-rpath,${carla_libdir} -L${carla_libdir} -lcarla_host-plugin
+Cflags: -DREAL_BUILD -I${includedir}/carla -I${includedir}/carla/includes

--- a/data/pkgconfig/carla-native-plugin.pc
+++ b/data/pkgconfig/carla-native-plugin.pc
@@ -1,9 +1,9 @@
 prefix=X-PREFIX-X
-libdir=X-LIBDIR-X/carla
-includedir=X-INCLUDEDIR-X/carla
+libdir=X-LIBDIR-X
+includedir=X-INCLUDEDIR-X
 
 Name: carla-native-plugin
 Version: X-VERSION-X
 Description: Carla Native Plugin
-Libs: -Wl,-rpath,${libdir} -L${libdir} -lcarla_native-plugin
-Cflags: -DREAL_BUILD -I${includedir} -I${includedir}/includes
+Libs: -Wl,-rpath,${libdir}/carla -L${libdir}/carla -lcarla_native-plugin
+Cflags: -DREAL_BUILD -I${includedir}/carla -I${includedir}/carla/includes

--- a/data/pkgconfig/carla-standalone.pc
+++ b/data/pkgconfig/carla-standalone.pc
@@ -1,9 +1,9 @@
 prefix=X-PREFIX-X
-libdir=X-LIBDIR-X/carla
-includedir=X-INCLUDEDIR-X/carla
+libdir=X-LIBDIR-X
+includedir=X-INCLUDEDIR-X
 
 Name: carla-standalone
 Version: X-VERSION-X
 Description: Carla Host Standalone
-Libs: -Wl,-rpath,${libdir} -L${libdir} -lcarla_standalone2
-Cflags: -DREAL_BUILD -I${includedir} -I${includedir}/includes
+Libs: -Wl,-rpath,${libdir}/carla -L${libdir}/carla -lcarla_standalone2
+Cflags: -DREAL_BUILD -I${includedir}/carla -I${includedir}/carla/includes

--- a/data/pkgconfig/carla-utils.pc
+++ b/data/pkgconfig/carla-utils.pc
@@ -1,9 +1,9 @@
 prefix=X-PREFIX-X
-libdir=X-LIBDIR-X/carla
-includedir=X-INCLUDEDIR-X/carla
+libdir=X-LIBDIR-X
+includedir=X-INCLUDEDIR-X
 
 Name: carla-utils
 Version: X-VERSION-X
 Description: Carla Host Utilities
-Libs: -Wl,-rpath,${libdir} -L${libdir} -lcarla_utils
-Cflags: -DREAL_BUILD -I${includedir} -I${includedir}/includes -I${includedir}/utils
+Libs: -Wl,-rpath,${libdir}/carla -L${libdir}/carla -lcarla_utils
+Cflags: -DREAL_BUILD -I${includedir}/carla -I${includedir}/carla/includes -I${includedir}/carla/utils


### PR DESCRIPTION
The pkgconfig files are installed in `$PREFIX/lib` so using `libdir=${prefix}/lib/carla` is confusing.

Most software pkgconfig files seem to match the includedir and libdir variables with the actual includedir and libdir during configuration.