### PR TITLE
Fix canvaspreview out-of-bounds panning for patchbay

### DIFF
--- a/source/frontend/widgets/canvaspreviewframe.py
+++ b/source/frontend/widgets/canvaspreviewframe.py
@@ -368,7 +368,7 @@ class CanvasPreviewFrame(QFrame):
             fixPos = True
 
         if fixPos:
-            globalPos = self.mapToGlobal(QPoint(self.fInitialX + x, self.fInitialY + y))
+            globalPos = self.mapToGlobal(QPoint(int(self.fInitialX + x), int(self.fInitialY + y)))
             self.cursor().setPos(globalPos)
 
         x = self.fRenderSource.width() * x / self.fInternalWidth


### PR DESCRIPTION
Using the small canvaspreview to pan the patchbay resulted in an exception when panning out of bounds of the window. In this case Carla tried to create a QPoint with two floats, for which qt has no constructor. This results in the panning to hang, as the event is "handled" with an exception.

Casting these two values to int lets qt create the QPoint and with that properly set the new cursor position, so panning can be done in all edges again, without having to be precise with the cursor positioning.

This is probably a left-over from a python2 to python3 migration, as python did integer divison by default.

---
Exception on my machine without the patch:
```
Traceback (most recent call last):
  File "/home/seba/projects/src/carla/source/frontend/widgets/canvaspreviewframe.py", line 180, in mousePressEvent
    self._updateMouseMode(event)
  File "/home/seba/projects/src/carla/source/frontend/widgets/canvaspreviewframe.py", line 398, in _updateMouseMode
    self._moveViewRect(event.x(), event.y())
  File "/home/seba/projects/src/carla/source/frontend/widgets/canvaspreviewframe.py", line 371, in _moveViewRect
    globalPos = self.mapToGlobal(QPoint(self.fInitialX + x, self.fInitialY + y))
TypeError: arguments did not match any overloaded call:
  QPoint(): too many arguments
  QPoint(int, int): argument 2 has unexpected type 'float'
  QPoint(QPoint): argument 1 has unexpected type 'int'
```

Another solution would be to use `//` everywhere in this method, but as everything else works and I just wanted the QPoint to be constructed properly I went with this option.