### PR TITLE
PyQt 5.15.8 PYQT_VERSION_STR import fix

### DIFF
--- a/source/frontend/carla_shared.py
+++ b/source/frontend/carla_shared.py
@@ -38,7 +38,7 @@ except:
 # ------------------------------------------------------------------------------------------------------------
 # Imports (PyQt5)
 
-from PyQt5.Qt import PYQT_VERSION_STR
+from PyQt5.QtCore import PYQT_VERSION_STR
 from PyQt5.QtCore import qFatal, QT_VERSION, QT_VERSION_STR, qWarning, QDir, QSettings
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QFileDialog, QMessageBox


### PR DESCRIPTION
when starting carla i get:

Traceback (most recent call last):
  File "/usr/share/carla/carla", line 22, in <module>
    from carla_host import *
  File "/usr/share/carla/carla_host.py", line 53, in <module>
    import ui_carla_host
  File "/usr/share/carla/ui_carla_host.py", line 847, in <module>
    from widgets.draggablegraphicsview import DraggableGraphicsView
  File "/usr/share/carla/widgets/draggablegraphicsview.py", line 30, in <module>
    from carla_shared import MACOS, CustomMessageBox, gCarla
  File "/usr/share/carla/carla_shared.py", line 41, in <module>
    from PyQt5.Qt import PYQT_VERSION_STR
ImportError: cannot import name 'PYQT_VERSION_STR' from 'PyQt5.Qt' (/usr/lib/python3.10/site-packages/PyQt5/Qt.abi3.so)

so just fixed the import for the latest PyQt