### PR TITLE
set some runtime script interpreters to /bin/sh

### DIFF
--- a/data/carla
+++ b/data/carla
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 PYTHON=$(which python3 2>/dev/null)
 

--- a/data/carla-bridge-lv2-modgui
+++ b/data/carla-bridge-lv2-modgui
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 PYTHON=$(which python3 2>/dev/null)
 

--- a/data/carla-control
+++ b/data/carla-control
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 PYTHON=$(which python3 2>/dev/null)
 

--- a/data/carla-database
+++ b/data/carla-database
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 PYTHON=$(which python3 2>/dev/null)
 

--- a/data/carla-jack-multi
+++ b/data/carla-jack-multi
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 PYTHON=$(which python3 2>/dev/null)
 

--- a/data/carla-jack-patchbayplugin
+++ b/data/carla-jack-patchbayplugin
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ -f "$(dirname ${0})/carla-utils.pc" ]; then
     cd "$(dirname ${0})/.."

--- a/data/carla-jack-single
+++ b/data/carla-jack-single
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 PYTHON=$(which python3 2>/dev/null)
 

--- a/data/carla-libdir
+++ b/data/carla-libdir
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # small script that only prints carla's libdir.
 # can be used to detect if carla is installed, and where to find its libcarla_standalone2.so file
 

--- a/data/carla-osc-gui
+++ b/data/carla-osc-gui
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 

--- a/data/carla-patchbay
+++ b/data/carla-patchbay
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 PYTHON=$(which python3 2>/dev/null)
 

--- a/data/carla-rack
+++ b/data/carla-rack
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 PYTHON=$(which python3 2>/dev/null)
 

--- a/data/carla-settings
+++ b/data/carla-settings
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 PYTHON=$(which python3 2>/dev/null)
 

--- a/data/copy-zynaddsubfx
+++ b/data/copy-zynaddsubfx
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 


### PR DESCRIPTION
nothing in these scripts make use of bash features, and they are actually posix sh, so use /bin/sh instead.

noticed this by installing carla and not actually having bash, but it works fine with just regular sh, so this is slightly more 'portable' :)