### PR TITLE
Fix build with musl libc 1.2.4

### DIFF
--- a/source/modules/water/files/File.cpp
+++ b/source/modules/water/files/File.cpp
@@ -1265,7 +1265,7 @@ private:
 //=====================================================================================================================
 namespace
 {
-   #ifdef CARLA_OS_LINUX
+   #ifdef __GLIBC__
     typedef struct stat64 water_statStruct;
     #define WATER_STAT    stat64
    #else


### PR DESCRIPTION
Musl 1.2.4 gated the LFS64 compatibility shims behind the _LARGEFILE64_SOURCE macro, and they will be removed entirely in musl 1.2.5. Instead, always use the normal stat function instead of stat64, and set -D_FILE_OFFSET_BITS=64, which ensures that functions will always be 64-bits on 32-bit glibc platforms (and does nothing on other platforms).