### PR TITLE
Allow configuration of Carla client name when headless

### DIFF
--- a/source/frontend/carla_host.py
+++ b/source/frontend/carla_host.py
@@ -3659,7 +3659,7 @@ def runHostWithoutUI(host):
     # Init engine
 
     audioDriver = setEngineSettings(host, None, oscPort)
-    if not host.engine_init(audioDriver, "Carla"):
+    if not host.engine_init(audioDriver, CARLA_CLIENT_NAME or "Carla"):
         print("Engine failed to initialize, possible reasons:\n%s" % host.get_last_error())
         sys.exit(1)
 


### PR DESCRIPTION
I read this issue https://github.com/falkTX/Carla/issues/1568, because I was running into a similar issue. Now that I had some time to poke the code, I noticed a relatively simple solution to my problem.

This should allow modifying the name of the pipewire/jack device when running headless mode with the same configuration option as when running with UI mode enabled.

Setting `CARLA_CLIENT_NAME` to any value will make the devices pick up that name instead of the default `"Carla"`.