### PR TITLE
cmake: Install host-plugin/native-plugin/standalone pkgconfig files

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1587,9 +1587,15 @@ install(TARGETS carla-headers-utils PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_IN
 
 if(NOT ${CARLA_BUILD_FRAMEWORKS} AND NOT MSVC)
   configure_file(carla-utils.pc.in carla-utils.pc @ONLY)
+  configure_file(carla-standalone.pc.in carla-standalone.pc @ONLY)
+  configure_file(carla-native-plugin.pc.in carla-native-plugin.pc @ONLY)
+  configure_file(carla-host-plugin.pc.in carla-host-plugin.pc @ONLY)
 
   install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/carla-utils.pc
+    ${CMAKE_CURRENT_BINARY_DIR}/carla-standalone.pc
+    ${CMAKE_CURRENT_BINARY_DIR}/carla-native-plugin.pc
+    ${CMAKE_CURRENT_BINARY_DIR}/carla-host-plugin.pc
     DESTINATION
       ${CMAKE_INSTALL_LIBDIR}/pkgconfig
   )

--- a/cmake/carla-host-plugin.pc.in
+++ b/cmake/carla-host-plugin.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+carla_libdir=${libdir}/carla
+
+Name: carla-host-plugin
+Version: @PROJECT_VERSION@
+Description: Carla Host as Native Plugin
+Libs: -Wl,-rpath,${carla_libdir} -L${carla_libdir} -lcarla_host-plugin
+Cflags: -I${includedir}/carla -I${includedir}/carla/includes

--- a/cmake/carla-native-plugin.pc.in
+++ b/cmake/carla-native-plugin.pc.in
@@ -1,0 +1,9 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: carla-native-plugin
+Version: @PROJECT_VERSION@
+Description: Carla Native Plugin
+Libs: -Wl,-rpath,${libdir}/carla -L${libdir}/carla -lcarla_native-plugin
+Cflags: -I${includedir}/carla -I${includedir}/carla/includes

--- a/cmake/carla-standalone.pc.in
+++ b/cmake/carla-standalone.pc.in
@@ -1,0 +1,9 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: carla-standalone
+Version: @PROJECT_VERSION@
+Description: Carla Host Standalone
+Libs: -Wl,-rpath,${libdir}/carla -L${libdir}/carla -lcarla_standalone2
+Cflags: -I${includedir}/carla -I${includedir}/carla/includes


### PR DESCRIPTION
This installs the missing pkgconfig files for host-plugin/native-plugin/standalone libraries.

carla-host-plugin.pc looks like this when installed (in prefix `/tmp/carlatest`):
```
prefix=/tmp/carlatest
libdir=/tmp/carlatest/lib
includedir=/tmp/carlatest/include
carla_libdir=${libdir}/carla

Name: carla-host-plugin
Version: 2.6.0-alpha1
Description: Carla Host as Native Plugin
Libs: -Wl,-rpath,${carla_libdir} -L${carla_libdir} -lcarla_host-plugin
Cflags: -I${includedir}/carla -I${includedir}/carla/includes
```