### PR TITLE
fix TCP unregister systematically fails

### DIFF
--- a/source/backend/engine/CarlaEngineOscHandlers.cpp
+++ b/source/backend/engine/CarlaEngineOscHandlers.cpp
@@ -245,6 +245,7 @@ int CarlaEngineOsc::handleMsgRegister(const bool isTCP,
 
         oscData.owner  = carla_strdup_safe(host);
         oscData.path   = carla_strdup_free(lo_url_get_path(url));
+        oscData.url = carla_strdup_safe(url);
         oscData.target = target;
 
         char* const targeturl = lo_address_get_url(target);
@@ -299,14 +300,14 @@ int CarlaEngineOsc::handleMsgUnregister(const bool isTCP,
 
     const char* const url = &argv[0]->s;
 
-    if (std::strcmp(oscData.owner, url) == 0)
+    if (std::strcmp(oscData.url, url) == 0)
     {
         carla_stdout("OSC client %s unregistered", url);
         oscData.clear();
         return 0;
     }
 
-    carla_stderr("OSC backend unregister failed, current owner %s does not match requested %s", oscData.owner, url);
+    carla_stderr("OSC backend unregister failed, current owner %s does not match requested %s", oscData.url, url);
     return 0;
 }
 

--- a/source/utils/CarlaOscUtils.hpp
+++ b/source/utils/CarlaOscUtils.hpp
@@ -32,12 +32,14 @@
 struct CarlaOscData {
     const char* owner;
     const char* path;
+    const char* url;
     lo_address source;
     lo_address target;
 
     CarlaOscData() noexcept
         : owner(nullptr),
           path(nullptr),
+          url(nullptr),
           source(nullptr),
           target(nullptr) {}
 
@@ -58,6 +60,12 @@ struct CarlaOscData {
         {
             delete[] path;
             path = nullptr;
+        }
+
+        if (url != nullptr)
+        {
+            delete[] url;
+            url = nullptr;
         }
 
         if (source != nullptr)


### PR DESCRIPTION
Hi.
The OSC TCP `/unregister` method systematically fails, because code compares the url argument to the saved hostname.

This method is used by `carla-control`, it means that it is not possible to stop carla-control, restart it and register again to the same carla instance.

This PR fixes the problem of course.

I need it because I use a self made TCP server connected to Carla to save/restore my presets.