### PR TITLE
carla_host_control: import from pyliblo3 if available

### DIFF
--- a/source/frontend/carla_host_control.py
+++ b/source/frontend/carla_host_control.py
@@ -23,16 +23,28 @@ from carla_host import *
 # ------------------------------------------------------------------------------------------------------------
 # Imports (liblo)
 
-from liblo import (
-  Address,
-  AddressError,
-  ServerError,
-  Server,
-  make_method,
-  send as lo_send,
-  TCP as LO_TCP,
-  UDP as LO_UDP,
-)
+try:
+    from pyliblo3 import (
+      Address,
+      AddressError,
+      ServerError,
+      Server,
+      make_method,
+      send as lo_send,
+      TCP as LO_TCP,
+      UDP as LO_UDP,
+    )
+except ModuleNotFoundError:
+    from liblo import (
+      Address,
+      AddressError,
+      ServerError,
+      Server,
+      make_method,
+      send as lo_send,
+      TCP as LO_TCP,
+      UDP as LO_UDP,
+    )
 
 from random import random
 


### PR DESCRIPTION
pyliblo has not been touched upstream since 2015 and doesn't work out of the box with Python releases since 3.11. There is an actively-maintained fork called 'pyliblo3' at
https://github.com/gesellkammer/pyliblo3 which *does* work with current upstream Python releases. It provides a library called 'pyliblo3' rather than 'liblo'. Let's support it, and prefer it over the dead library (though the dead one will still be used if it is present and pyliblo3 is not).