### PR TITLE
VST Params: UI left align param titles for easier reading

### DIFF
--- a/resources/ui/carla_parameter.ui
+++ b/resources/ui/carla_parameter.ui
@@ -23,7 +23,7 @@
       <string>Parameter Name</string>
      </property>
      <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      <set>Qt::AlignLeft|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
When the number of parameters are large, its really difficult to locate a certain parameter, since the current behavior is that it alights to the right, which makes every label starts in a different position depending on its char length