### PR TITLE
Fix support for CYGWIN

### DIFF
--- a/source/includes/CarlaDefines.h
+++ b/source/includes/CarlaDefines.h
@@ -38,6 +38,8 @@
 # define CARLA_OS_WIN32
 #elif defined(__APPLE__)
 # define CARLA_OS_MAC
+#elif defined(__CYGWIN__)
+# define CARLA_OS_CYGWIN
 #elif defined(__HAIKU__)
 # define CARLA_OS_HAIKU
 #elif defined(__linux__) || defined(__linux)
@@ -54,7 +56,7 @@
 
 #if defined(CARLA_OS_WIN32) || defined(CARLA_OS_WIN64)
 # define CARLA_OS_WIN
-#elif defined(CARLA_OS_BSD) || defined(CARLA_OS_GNU_HURD) || defined(CARLA_OS_LINUX) || defined(CARLA_OS_MAC)
+#elif defined(CARLA_OS_BSD) || defined(CARLA_OS_GNU_HURD) || defined(CARLA_OS_LINUX) || defined(CARLA_OS_MAC) || defined(CARLA_OS_CYGWIN)
 # define CARLA_OS_UNIX
 #endif
 


### PR DESCRIPTION
Carla doesn't work on CYGWIN and the message:
```
Unsupported platform!
```
is printed on the console when building.
The macro `CARLA_OS_UNIX` is needed to make a working executable for CYGWIN, so I added `CARLA_OS_CYGWIN`, to be included together with existing macros. Hopefully, it is an easy fix and it has solved all the problems here. Tested with latest development version of Lmms at the time of writing.