### PR TITLE
Add platform detection and define LINUX constant early in carla-plugin

### DIFF
--- a/source/frontend/carla-plugin
+++ b/source/frontend/carla-plugin
@@ -5,6 +5,9 @@
 # ------------------------------------------------------------------------------------------------------------
 # Imports (Global)
 
+import platform
+LINUX = platform.system() == "Linux"
+
 from qt_compat import qt_config
 
 if qt_config == 5:


### PR DESCRIPTION
Imported the platform module and defined the LINUX constant at the top of the script, before any usage.   This ensures the LINUX flag is correctly set before it is referenced later in the code, preventing potential runtime errors.

---

Basically, trying to use the Carla Patchbay or Carla rack plugin in any DAW on Linux caused Carla to not work because of the unreferenced variable "LINUX" -- which i assume was supposed to declare whether or not the platform is Linux(especially since the problem only happens on linux and also just based on the name).
My fix was simple: import platform and use it to check if platform is "Linux" and set the LINUX variable based on that

This issue seems to have come from a very recent commit(came in 5 days ago) so having a mistake like that is still reasonable. Still glad I was able to fix it!