### PR TITLE
OSC: Support addressing plugins by name

### DIFF
--- a/source/backend/engine/CarlaEngineOscHandlers.cpp
+++ b/source/backend/engine/CarlaEngineOscHandlers.cpp
@@ -142,7 +142,6 @@ int CarlaEngineOsc::handleMessage(const bool isTCP, const char* const path,
         {
             plugin = fEngine->getPluginUnchecked(pluginId);
 
-            carla_stderr("%s %s %d\n", plugin->getName(), pluginPath, pluginLen);
             if (strlen(plugin->getName()) == pluginLen && !strncmp(plugin->getName(), pluginPath, pluginLen)) {
                 break;
             }

--- a/source/frontend/C++/carla_widgets.cpp
+++ b/source/frontend/C++/carla_widgets.cpp
@@ -118,7 +118,8 @@ struct CarlaAboutW::PrivateData {
                                "</table>");
 
         ui.l_example->setText("/Carla/2/set_parameter_value 5 1.0");
-        ui.l_example_help->setText("<i>(as in this example, \"2\" is the plugin number and \"5\" the parameter)</i>");
+        ui.l_example_help->setText("<i>(In this example, \"2\" is the plugin number and \"5\" the parameter.<br>"
+                                   "Plugins can also be referenced by their name.)</i>");
 
         ui.l_ladspa->setText(tr("Everything! (Including LRDF)"));
         ui.l_dssi->setText(tr("Everything! (Including CustomData/Chunks)"));

--- a/source/frontend/dialogs/aboutdialog.cpp
+++ b/source/frontend/dialogs/aboutdialog.cpp
@@ -72,7 +72,8 @@ AboutDialog::AboutDialog(QWidget* const parent,
                            "</table>");
 
     ui.l_example->setText("/Carla/2/set_parameter_value 5 1.0");
-    ui.l_example_help->setText("<i>(as in this example, \"2\" is the plugin number and \"5\" the parameter)</i>");
+    ui.l_example_help->setText("<i>(In this example, \"2\" is the plugin number and \"5\" the parameter.<br>"
+                              "Plugins can also be referenced by their name.)</i>");
 
     ui.l_ladspa->setText(tr("Everything! (Including LRDF)"));
     ui.l_dssi->setText(tr("Everything! (Including CustomData/Chunks)"));


### PR DESCRIPTION
On a complex patchbay, it's very difficult to keep plugins at a known, consistent ID. Removing a plugin would shift the IDs of all subsequent plugins. This makes using OSC to control them very cumbersome.

Add support for addressing plugins by name, such as `/Carla/Audio Gain (Mono)/set_parameter_value`. For complex patchbays, the user can then rename the plugins to have helpful names indicating their purpose (and, if desired, avoid spaces), making the OSC addressing more natural and less error-prone.