### PR TITLE
Handle multiple buffer sizes in multi-client mode

### DIFF
--- a/source/backend/engine/CarlaEngine.cpp
+++ b/source/backend/engine/CarlaEngine.cpp
@@ -2249,14 +2249,19 @@ void CarlaEngine::bufferSizeChanged(const uint32_t newBufferSize)
 
     pData->time.updateAudioValues(newBufferSize, pData->sampleRate);
 
-    for (uint i=0; i < pData->curPluginCount; ++i)
+#ifndef BUILD_BRIDGE
+    if (pData->options.processMode != ENGINE_PROCESS_MODE_MULTIPLE_CLIENTS)
+#endif
     {
-        if (const CarlaPluginPtr plugin = pData->plugins[i].plugin)
+        for (uint i=0; i < pData->curPluginCount; ++i)
         {
-            if (plugin->isEnabled() && plugin->tryLock(true))
+            if (const CarlaPluginPtr plugin = pData->plugins[i].plugin)
             {
-                plugin->bufferSizeChanged(newBufferSize);
-                plugin->unlock();
+                if (plugin->isEnabled() && plugin->tryLock(true))
+                {
+                    plugin->bufferSizeChanged(newBufferSize);
+                    plugin->unlock();
+                }
             }
         }
     }
@@ -2278,14 +2283,19 @@ void CarlaEngine::sampleRateChanged(const double newSampleRate)
 
     pData->time.updateAudioValues(pData->bufferSize, newSampleRate);
 
-    for (uint i=0; i < pData->curPluginCount; ++i)
+#ifndef BUILD_BRIDGE
+    if (pData->options.processMode != ENGINE_PROCESS_MODE_MULTIPLE_CLIENTS)
+#endif
     {
-        if (const CarlaPluginPtr plugin = pData->plugins[i].plugin)
+        for (uint i=0; i < pData->curPluginCount; ++i)
         {
-            if (plugin->isEnabled() && plugin->tryLock(true))
+            if (const CarlaPluginPtr plugin = pData->plugins[i].plugin)
             {
-                plugin->sampleRateChanged(newSampleRate);
-                plugin->unlock();
+                if (plugin->isEnabled() && plugin->tryLock(true))
+                {
+                    plugin->sampleRateChanged(newSampleRate);
+                    plugin->unlock();
+                }
             }
         }
     }

--- a/source/backend/engine/CarlaEngineJack.cpp
+++ b/source/backend/engine/CarlaEngineJack.cpp
@@ -838,9 +838,27 @@ public:
         {
             CARLA_SAFE_ASSERT_RETURN(fJackClient != nullptr && ! isActive(),);
 
+#ifndef BUILD_BRIDGE
+            // When JACK is activated, some callbacks will be called synchronously.
+            // These callbacks must not re-lock the plugin, or else they would
+            // deadlock. Set a flag to tell them to elide locking, since we are
+            // already in a safe context (no other thread can lock the plugin).
+            fActivating = true;
+#endif
             try {
                 jackbridge_activate(fJackClient);
             } catch(...) {}
+#ifndef BUILD_BRIDGE
+            // Release the activation flag. From this point onwards non-RT callbacks
+            // will lock the plugin. Since one such callback could have been called
+            // twice, with the second instance not blocking after activate and
+            // concurrently executing, we lock the callback lock before doing this.
+            fCallbackLock.lock();
+            fActivating = false;
+            fCallbackLock.unlock();
+            // After this point, no callbacks will be running nor able to run until
+            // the plugin mutex is released in CarlaPlugin::setEnabled().
+#endif
         }
 
         CarlaEngineClient::activate();
@@ -1191,9 +1209,31 @@ public:
     }
 #endif
 
+#ifndef BUILD_BRIDGE
+    void maybeLockPlugin(CarlaPluginPtr plugin)
+    {
+        fCallbackLock.lock();
+        if (!fActivating)
+            plugin->tryLock(true);
+    }
+
+    void maybeUnlockPlugin(CarlaPluginPtr plugin)
+    {
+        if (!fActivating)
+            plugin->unlock();
+
+        fCallbackLock.unlock();
+    }
+#endif
+
 private:
     jack_client_t* fJackClient;
     const bool     fUseClient;
+
+#ifndef BUILD_BRIDGE
+    CarlaMutex     fCallbackLock;
+    bool           fActivating;
+#endif
 
     LinkedList<CarlaEngineJackAudioPort*> fAudioPorts;
     LinkedList<CarlaEngineJackCVPort*>    fCVPorts;
@@ -2005,10 +2045,8 @@ public:
 
 #ifndef BUILD_BRIDGE
             pluginReserve = new CarlaPluginPtr(plugin);
-            /*
-            jackbridge_set_buffer_size_callback(fClient, carla_jack_bufsize_callback_plugin, pluginReserve);
-            jackbridge_set_sample_rate_callback(fClient, carla_jack_srate_callback_plugin, pluginReserve);
-            */
+            jackbridge_set_buffer_size_callback(client, carla_jack_bufsize_callback_plugin, pluginReserve);
+            jackbridge_set_sample_rate_callback(client, carla_jack_srate_callback_plugin, pluginReserve);
             // jackbridge_set_latency_callback(client, carla_jack_latency_callback_plugin, pluginReserve);
             jackbridge_set_process_callback(client, carla_jack_process_callback_plugin, pluginReserve);
             jackbridge_on_shutdown(client, carla_jack_shutdown_callback_plugin, pluginReserve);
@@ -4421,25 +4459,39 @@ private:
         return 0;
     }
 
-    /*
     static int JACKBRIDGE_API carla_jack_bufsize_callback_plugin(jack_nframes_t nframes, void* arg)
     {
-        CarlaPlugin* const plugin((CarlaPlugin*)arg);
-        CARLA_SAFE_ASSERT_RETURN(plugin != nullptr && plugin->isEnabled(), 0);
+        CarlaPluginPtr* const pluginPtr = static_cast<CarlaPluginPtr*>(arg);
+        CARLA_SAFE_ASSERT_RETURN(pluginPtr != nullptr, 0);
 
+        CarlaPluginPtr plugin = *pluginPtr;
+        CARLA_SAFE_ASSERT_RETURN(plugin.get() != nullptr && plugin->isEnabled(), 0);
+
+        CarlaEngineJackClient* const engineClient((CarlaEngineJackClient*)plugin->getEngineClient());
+        CARLA_SAFE_ASSERT_RETURN(engineClient != nullptr, 0);
+
+        engineClient->maybeLockPlugin(plugin);
         plugin->bufferSizeChanged(nframes);
+        engineClient->maybeUnlockPlugin(plugin);
         return 1;
     }
 
     static int JACKBRIDGE_API carla_jack_srate_callback_plugin(jack_nframes_t nframes, void* arg)
     {
-        CarlaPlugin* const plugin((CarlaPlugin*)arg);
-        CARLA_SAFE_ASSERT_RETURN(plugin != nullptr && plugin->isEnabled(), 0);
+        CarlaPluginPtr* const pluginPtr = static_cast<CarlaPluginPtr*>(arg);
+        CARLA_SAFE_ASSERT_RETURN(pluginPtr != nullptr, 0);
 
+        CarlaPluginPtr plugin = *pluginPtr;
+        CARLA_SAFE_ASSERT_RETURN(plugin.get() != nullptr && plugin->isEnabled(), 0);
+
+        CarlaEngineJackClient* const engineClient((CarlaEngineJackClient*)plugin->getEngineClient());
+        CARLA_SAFE_ASSERT_RETURN(engineClient != nullptr, 0);
+
+        engineClient->maybeLockPlugin(plugin);
         plugin->sampleRateChanged(nframes);
+        engineClient->maybeUnlockPlugin(plugin);
         return 1;
     }
-    */
 
     static void JACKBRIDGE_API carla_jack_latency_callback_plugin(jack_latency_callback_mode_t /*mode*/, void* /*arg*/)
     {


### PR DESCRIPTION
In multiple clients mode, each plugin is a separate client and could have its own buffer size. In particular, with PipeWire, a buffer size change might be queued for the main client, and not delivered before the process callback is called for a plugin client, causing segfaults.

Hook up the buffer size / sample rate callback to clients, and do not call them from the engine code in multi client mode.

Note: By default, PipeWire synchronizes the buffer size of all JACK clients. However, this change is still necessary even then, because PipeWire does not guarantee delivery of a buffer size callback for one client before `process()` is called for another client. For example, this:

* (buffer size change 128 -> 256)
* plugin1: `bufsizechanged(256)`
* plugin1: `process(256)`
* mainengine: `bufsizechanged(256)`
* mainengine: `process(256)`

is possible, and this causes segfaults with Carla on PipeWire even with no extra configuration settings, unless the quantum is globally set in advance, since as plugin connections are made during startup the "global JACK buffer size" will change.

To actually test mixed buffer sizes in Carla on a continuous basis, you have to do something like this:

```
$ cat  .config/pipewire/jack.conf.d/test.conf 
jack.rules = [
    {
        matches = [
            {
                client.name = "Audio Gain (Stereo)"
            }
        ]
        actions = {
            update-props = {
                node.group = "mygroup"
            }
        }
    }
]
```

This will cause a plugin called `Audio Gain (Stereo)` to be scheduled with its own buffer size, not synchronized with all other JACK clients. Then, connecting that plugin to an audio device with one default buffer size, and (any) different plugin to another audio device with another default buffer size, will cause Carla to be processing a different buffer size for each plugin.

Fixes common segfaults during Carla initialization, or while changing buffer sizes at runtime.