### PR TITLE
Make scale point patch for LV2 compatible across versions.

### DIFF
--- a/source/backend/engine/CarlaEngineNative.cpp
+++ b/source/backend/engine/CarlaEngineNative.cpp
@@ -589,6 +589,9 @@ protected:
                 CARLA_SAFE_ASSERT_RETURN(fUiServer.writeEmptyMessage(),);
             }
 
+            std::snprintf(tmpBuf, STR_MAX, "%i\n", plugin->getParameterScalePointCount(i));
+            CARLA_SAFE_ASSERT_RETURN(fUiServer.writeMessage(tmpBuf),);
+
             std::snprintf(tmpBuf, STR_MAX, "PARAMETER_RANGES_%i:%i\n", pluginId, i);
             CARLA_SAFE_ASSERT_RETURN(fUiServer.writeMessage(tmpBuf),);
 
@@ -606,6 +609,20 @@ protected:
 
             std::snprintf(tmpBuf, STR_MAX, "%.12g\n", static_cast<double>(plugin->getParameterValue(i)));
             CARLA_SAFE_ASSERT_RETURN(fUiServer.writeMessage(tmpBuf),);
+
+            for (uint32_t p = 0; p < plugin->getParameterScalePointCount(i); p++) {
+                std::snprintf(tmpBuf, STR_MAX, "PARAMETER_SCALEPOINT_%i:%i:%i\n", pluginId, i, p);
+                CARLA_SAFE_ASSERT_RETURN(fUiServer.writeMessage(tmpBuf),);
+
+                std::snprintf(tmpBuf, STR_MAX, "%.12g\n", plugin->getParameterScalePointValue(i, p));
+                CARLA_SAFE_ASSERT_RETURN(fUiServer.writeMessage(tmpBuf),);
+
+                if (plugin->getParameterScalePointLabel(i, p, tmpBuf)) {
+                    CARLA_SAFE_ASSERT_RETURN(fUiServer.writeAndFixMessage(tmpBuf),);
+                } else {
+                    CARLA_SAFE_ASSERT_RETURN(fUiServer.writeEmptyMessage(),);
+                }
+            }
         }
 
         fUiServer.syncMessages();

--- a/source/backend/engine/CarlaEngineNative.cpp
+++ b/source/backend/engine/CarlaEngineNative.cpp
@@ -589,6 +589,8 @@ protected:
                 CARLA_SAFE_ASSERT_RETURN(fUiServer.writeEmptyMessage(),);
             }
 
+            std::snprintf(tmpBuf, STR_MAX, "PARAMETER_SCALEPOINT_COUNT_%i:%i\n", pluginId, i);
+            CARLA_SAFE_ASSERT_RETURN(fUiServer.writeMessage(tmpBuf),);
             std::snprintf(tmpBuf, STR_MAX, "%i\n", plugin->getParameterScalePointCount(i));
             CARLA_SAFE_ASSERT_RETURN(fUiServer.writeMessage(tmpBuf),);
 

--- a/source/frontend/carla-plugin
+++ b/source/frontend/carla-plugin
@@ -280,6 +280,7 @@ class CarlaMiniW(ExternalUI, HostWindow):
             paramUnit = self.readlineblock()
             paramComment = self.readlineblock()
             paramGroupName = self.readlineblock()
+            scalePointCount = int(self.readlineblock())
 
             paramInfo = {
                 'name': paramName,
@@ -287,7 +288,7 @@ class CarlaMiniW(ExternalUI, HostWindow):
                 'unit': paramUnit,
                 'comment': paramComment,
                 'groupName': paramGroupName,
-                'scalePointCount': 0,
+                'scalePointCount': scalePointCount,
             }
             self.host._set_parameterInfo(pluginId, paramId, paramInfo)
 
@@ -316,6 +317,12 @@ class CarlaMiniW(ExternalUI, HostWindow):
                 'stepLarge': stepLarge
             }
             self.host._set_parameterRanges(pluginId, paramId, paramRanges)
+
+        elif msg.startswith("PARAMETER_SCALEPOINT_"):
+            pluginId, param, point = [int(i) for i in msg.replace("PARAMETER_SCALEPOINT_", "").split(":")]
+            value = float(self.readlineblock())
+            label = self.readlineblock()
+            self.host._set_parameterScalePoint(pluginId, param, point, value, label)
 
         elif msg.startswith("PROGRAM_COUNT_"):
             pluginId, count, current = [int(i) for i in msg.replace("PROGRAM_COUNT_", "").split(":")]

--- a/source/frontend/carla-plugin
+++ b/source/frontend/carla-plugin
@@ -280,7 +280,6 @@ class CarlaMiniW(ExternalUI, HostWindow):
             paramUnit = self.readlineblock()
             paramComment = self.readlineblock()
             paramGroupName = self.readlineblock()
-            scalePointCount = int(self.readlineblock())
 
             paramInfo = {
                 'name': paramName,
@@ -288,7 +287,7 @@ class CarlaMiniW(ExternalUI, HostWindow):
                 'unit': paramUnit,
                 'comment': paramComment,
                 'groupName': paramGroupName,
-                'scalePointCount': scalePointCount,
+                'scalePointCount': 0,
             }
             self.host._set_parameterInfo(pluginId, paramId, paramInfo)
 
@@ -317,6 +316,11 @@ class CarlaMiniW(ExternalUI, HostWindow):
                 'stepLarge': stepLarge
             }
             self.host._set_parameterRanges(pluginId, paramId, paramRanges)
+
+        elif msg.startswith("PARAMETER_SCALEPOINT_COUNT_"):
+            pluginId, paramId = [int(i) for i in msg.replace("PARAMETER_SCALEPOINT_COUNT_", "").split(":")]
+            scalePointCount = int(self.readlineblock())
+            self.host._set_parameterScalePointCount(pluginId, paramId, scalePointCount)
 
         elif msg.startswith("PARAMETER_SCALEPOINT_"):
             pluginId, param, point = [int(i) for i in msg.replace("PARAMETER_SCALEPOINT_", "").split(":")]

--- a/source/frontend/carla_backend.py
+++ b/source/frontend/carla_backend.py
@@ -3272,6 +3272,7 @@ class PluginStoreInfo():
         self.parameterData   = []
         self.parameterRanges = []
         self.parameterValues = []
+        self.parameterScalePoints = []
         self.programCount   = 0
         self.programCurrent = -1
         self.programNames   = []
@@ -3484,7 +3485,7 @@ class CarlaHostPlugin(CarlaHostMeta):
         return self.fPluginsInfo.get(pluginId, self.fFallbackPluginInfo).parameterInfo[parameterId]
 
     def get_parameter_scalepoint_info(self, pluginId, parameterId, scalePointId):
-        return PyCarlaScalePointInfo
+        return self.fPluginsInfo.get(pluginId, self.fFallbackPluginInfo).parameterScalePoints[parameterId][scalePointId]
 
     def get_parameter_data(self, pluginId, parameterId):
         return self.fPluginsInfo.get(pluginId, self.fFallbackPluginInfo).parameterData[parameterId]
@@ -3765,6 +3766,7 @@ class CarlaHostPlugin(CarlaHostMeta):
         plugin.parameterData  = []
         plugin.parameterRanges = []
         plugin.parameterValues = []
+        plugin.parameterScalePoints = []
 
         # add placeholders
         for _ in range(count):
@@ -3772,6 +3774,26 @@ class CarlaHostPlugin(CarlaHostMeta):
             plugin.parameterData.append(PyParameterData.copy())
             plugin.parameterRanges.append(PyParameterRanges.copy())
             plugin.parameterValues.append(0.0)
+            plugin.parameterScalePoints.append([])
+
+    def _set_parameterScalePoint(self, pluginId, param, point, value, label):
+        plugin = self.fPluginsInfo.get(pluginId, None)
+        if plugin is None:
+            print("_set_parameterScalePointCount failed for", pluginId)
+            return
+
+        if param < 0 or param >= plugin.parameterCount:
+            print("_set_parameterScalePointCount failed for parameter", param)
+            return
+
+        if point < 0 or point >= plugin.parameterInfo[param]["scalePointCount"]:
+            print("_set_parameterScalePointCount failed for scale point", point)
+            return
+
+        plugin.parameterScalePoints[param][point] = {
+            "value": value,
+            "label": label,
+        }
 
     def _set_programCount(self, pluginId, count):
         plugin = self.fPluginsInfo.get(pluginId, None)
@@ -3809,6 +3831,11 @@ class CarlaHostPlugin(CarlaHostMeta):
             plugin.parameterInfo[paramIndex] = info
         else:
             print("_set_parameterInfo failed for", pluginId, "and index", paramIndex)
+
+        # add placeholders
+        plugin.parameterScalePoints[paramIndex] = []
+        for _ in range(info["scalePointCount"]):
+            plugin.parameterScalePoints[paramIndex].append({})
 
     def _set_parameterData(self, pluginId, paramIndex, data):
         plugin = self.fPluginsInfo.get(pluginId, None)

--- a/source/frontend/carla_backend.py
+++ b/source/frontend/carla_backend.py
@@ -3829,13 +3829,13 @@ class CarlaHostPlugin(CarlaHostMeta):
             return
         if paramIndex < plugin.parameterCount:
             plugin.parameterInfo[paramIndex] = info
+
+            # add placeholders
+            plugin.parameterScalePoints[paramIndex] = []
+            for _ in range(info["scalePointCount"]):
+                plugin.parameterScalePoints[paramIndex].append({})
         else:
             print("_set_parameterInfo failed for", pluginId, "and index", paramIndex)
-
-        # add placeholders
-        plugin.parameterScalePoints[paramIndex] = []
-        for _ in range(info["scalePointCount"]):
-            plugin.parameterScalePoints[paramIndex].append({})
 
     def _set_parameterData(self, pluginId, paramIndex, data):
         plugin = self.fPluginsInfo.get(pluginId, None)

--- a/source/frontend/carla_backend.py
+++ b/source/frontend/carla_backend.py
@@ -3779,15 +3779,15 @@ class CarlaHostPlugin(CarlaHostMeta):
     def _set_parameterScalePoint(self, pluginId, param, point, value, label):
         plugin = self.fPluginsInfo.get(pluginId, None)
         if plugin is None:
-            print("_set_parameterScalePointCount failed for", pluginId)
+            print("_set_parameterScalePoint failed for", pluginId)
             return
 
         if param < 0 or param >= plugin.parameterCount:
-            print("_set_parameterScalePointCount failed for parameter", param)
+            print("_set_parameterScalePoint failed for parameter", param)
             return
 
         if point < 0 or point >= plugin.parameterInfo[param]["scalePointCount"]:
-            print("_set_parameterScalePointCount failed for scale point", point)
+            print("_set_parameterScalePoint failed for scale point", point)
             return
 
         plugin.parameterScalePoints[param][point] = {

--- a/source/frontend/carla_backend.py
+++ b/source/frontend/carla_backend.py
@@ -3829,13 +3829,23 @@ class CarlaHostPlugin(CarlaHostMeta):
             return
         if paramIndex < plugin.parameterCount:
             plugin.parameterInfo[paramIndex] = info
+        else:
+            print("_set_parameterInfo failed for", pluginId, "and index", paramIndex)
+
+    def _set_parameterScalePointCount(self, pluginId, paramIndex, count):
+        plugin = self.fPluginsInfo.get(pluginId, None)
+        if plugin is None:
+            print("_set_parameterScalePointCount failed for", pluginId)
+            return
+        if paramIndex < plugin.parameterCount and paramIndex < len(plugin.parameterInfo):
+            plugin.parameterInfo[paramIndex]["scalePointCount"] = count
 
             # add placeholders
             plugin.parameterScalePoints[paramIndex] = []
-            for _ in range(info["scalePointCount"]):
+            for _ in range(count):
                 plugin.parameterScalePoints[paramIndex].append({})
         else:
-            print("_set_parameterInfo failed for", pluginId, "and index", paramIndex)
+            print("_set_parameterScalePointCount failed for", pluginId, "and index", paramIndex)
 
     def _set_parameterData(self, pluginId, paramIndex, data):
         plugin = self.fPluginsInfo.get(pluginId, None)


### PR DESCRIPTION
This is based on #2020, but contains additional compatibility code for that feature.

Use a dedicated `PARAMETER_SCALEPOINT_COUNT` statement in the protocol, so that old versions ignore it, instead of getting out of sync with the protocol and failing altogether.

This helps for example to run an updated Carla and an older Carla-inside-Cardinal side by side.

I submitted this separately from #2020 so it could be decided whether this is necessary or not. It is definitely nice to have as long as #2020 is not merged into mainline, at least.