### PR TITLE
Partial revert of plugin discovery timeout reduction.

### DIFF
--- a/source/backend/utils/PluginDiscovery.cpp
+++ b/source/backend/utils/PluginDiscovery.cpp
@@ -526,10 +526,10 @@ private:
 
            #ifndef CARLA_OS_WIN
             if (helperTool.isNotEmpty())
-                startPipeServer(helperTool.toRawUTF8(), fDiscoveryTool, getPluginTypeAsString(fPluginType), ":all", -1, 2000);
+                startPipeServer(helperTool.toRawUTF8(), fDiscoveryTool, getPluginTypeAsString(fPluginType), ":all");
             else
            #endif
-                startPipeServer(fDiscoveryTool, getPluginTypeAsString(fPluginType), ":all", -1, 2000);
+                startPipeServer(fDiscoveryTool, getPluginTypeAsString(fPluginType), ":all");
         }
         else
         {
@@ -552,10 +552,10 @@ private:
 
            #ifndef CARLA_OS_WIN
             if (helperTool.isNotEmpty())
-                startPipeServer(helperTool.toRawUTF8(), fDiscoveryTool, getPluginTypeAsString(fPluginType), filename.toRawUTF8(), -1, 2000);
+                startPipeServer(helperTool.toRawUTF8(), fDiscoveryTool, getPluginTypeAsString(fPluginType), filename.toRawUTF8());
             else
            #endif
-                startPipeServer(fDiscoveryTool, getPluginTypeAsString(fPluginType), filename.toRawUTF8(), -1, 2000);
+                startPipeServer(fDiscoveryTool, getPluginTypeAsString(fPluginType), filename.toRawUTF8());
         }
     }
 


### PR DESCRIPTION
This is a partial revert of 78cff157400c8d97940ca9bc3dd100b14dfa0cdb.

Two seconds isn't long enough for some of the heavier plugins, such as the wine-loaded Kontakt Player. Without reverting this change, this plugin is not discoverable.